### PR TITLE
fix(tui): rewrite relative README links to GitHub URLs on landing site

### DIFF
--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -14,6 +14,15 @@ const __dirname = dirname(__filename);
 const readmePath = join(__dirname, '../../../../README.md');
 const readmeContent = readFileSync(readmePath, 'utf-8');
 
+const GITHUB_BLOB =
+  'https://github.com/junhoyeo/contrabass/blob/main/';
+const GITHUB_TREE =
+  'https://github.com/junhoyeo/contrabass/tree/main/';
+
+function isRelative(href: string): boolean {
+  return !!href && !href.startsWith('http') && !href.startsWith('#') && !href.startsWith('mailto:');
+}
+
 const parser = new Marked(
   markedHighlight({
     langPrefix: 'hljs language-',
@@ -21,7 +30,17 @@ const parser = new Marked(
       const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
       return hljs.highlight(code, { language }).value;
     },
-  })
+  }),
+  {
+    walkTokens(token) {
+      if (token.type === 'link' && isRelative(token.href)) {
+        token.href = (token.href.endsWith('/') ? GITHUB_TREE : GITHUB_BLOB) + token.href;
+      }
+      if (token.type === 'image' && isRelative(token.href)) {
+        token.href = GITHUB_BLOB + token.href;
+      }
+    },
+  },
 );
 
 const htmlContent = parser.parse(readmeContent);


### PR DESCRIPTION
## Summary

- Relative links in README.md (e.g. `testdata/workflow.demo.md`, `docs/codex-protocol.md`, `CONTRIBUTING.md`) resolve correctly on GitHub but 404 on the Vercel landing site
- Add `walkTokens` hook to the `marked` parser in `index.astro` that rewrites relative link/image hrefs to full GitHub URLs (`/blob/main/` for files, `/tree/main/` for directories)
- Fixes all existing broken links and prevents future ones as new relative links are added to README

Ref: https://github.com/junhoyeo/contrabass/pull/24#issuecomment-4018805059
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/contrabass/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
