### PR TITLE
fix(web): guard runtime display against Go zero time

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -17,7 +17,8 @@ function computeRuntimeSeconds(startTime: string | undefined): number {
   }
 
   const start = Date.parse(startTime)
-  if (Number.isNaN(start)) {
+  // Guard against Go zero time ("0001-01-01T00:00:00Z") and other pre-epoch dates
+  if (Number.isNaN(start) || start <= 0) {
     return 0
   }
 


### PR DESCRIPTION
## Summary

- Fix dashboard runtime pill showing `1065143085m 54s` instead of `0m 0s` when backend sends Go's zero time (`0001-01-01T00:00:00Z`)
- Add `start <= 0` guard in `computeRuntimeSeconds()` to reject pre-epoch timestamps, matching the TUI's existing `!StartTime.IsZero()` check

## Bug

When the orchestrator hasn't started (team mode init, dry-run), the state API returns `StartTime: "0001-01-01T00:00:00Z"`. `Date.parse()` parses this to ~-62B ms, making `Date.now() - start` produce ~2026 years of runtime.

## Fix

```diff
- if (Number.isNaN(start)) {
+ if (Number.isNaN(start) || start <= 0) {
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/junhoyeo/contrabass/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
