### PR TITLE
fix(agent): update OpenCode API request format to use parts array

### DIFF
--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -544,7 +544,11 @@ func (r *OpenCodeRunner) createSession(ctx context.Context, serverURL string) (s
 }
 
 func (r *OpenCodeRunner) submitPrompt(ctx context.Context, serverURL, sessionID, prompt string) error {
-	body := map[string]interface{}{"content": prompt}
+	body := map[string]interface{}{
+		"parts": []map[string]interface{}{
+			{"type": "text", "text": prompt},
+		},
+	}
 	resp, err := r.doRequest(ctx, http.MethodPost, serverURL+"/session/"+sessionID+"/prompt_async", body, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

The current Contrabass code sends prompts to OpenCode using:
```json
{"content": "prompt text"}
```

But OpenCode's API expects:
```json
{"parts": [{"type": "text", "text": "prompt text"}]}
```

## Error Without Fix

Without this fix, the OpenCode API returns an error because it cannot parse the `content` field, resulting in failed prompt submissions.

## Solution

Updated the `submitPrompt` function in `internal/agent/opencode.go` (line 547) to use the correct request body format with a `parts` array containing text parts.

## Changes

- Changed request body from `{"content": prompt}` to `{"parts": [{"type": "text", "text": prompt}]}`
- This aligns with OpenCode's expected API format

## Testing

- Verified the fix compiles successfully
- The new format matches the OpenCode API specification for prompt submission

## Related

This fix ensures compatibility with the OpenCode API's expected request format for the `/session/{id}/prompt_async` endpoint.