### PR TITLE
fix(orchestrator): add session.status to recognized success signals for OpenCode

### DIFF
--- a/internal/orchestrator/orchestrator_runtime.go
+++ b/internal/orchestrator/orchestrator_runtime.go
@@ -209,7 +209,7 @@ func hasExplicitSuccessSignal(message string) bool {
 	}
 
 	switch normalized {
-	case "turn/completed", "item/completed", "task/completed":
+	case "turn/completed", "item/completed", "task/completed", "session.status":
 		return true
 	}
 


### PR DESCRIPTION
## Problem

When using OpenCode with Contrabass, the orchestrator fails to recognize task completion, throwing a \"missing explicit success signal\" error. This happens because OpenCode sends a `session.status` event to indicate task completion, but Contrabass only recognizes traditional completion signals like `turn/completed`, `item/completed`, and `task/completed`.

## Why OpenCode Uses session.status

OpenCode (unlike other agents) uses a `session.status` event as its completion signal. This is part of OpenCode's session-based architecture where:
- Traditional agents send explicit completion events (e.g., `turn/completed`)
- OpenCode signals completion via session status updates
- The session.status event indicates the session has finished processing

## The Fix

This PR adds `session.status` to the list of recognized success signals in the `hasExplicitSuccessSignal` function:

```go
switch normalized {
case "turn/completed", "item/completed", "task/completed", "session.status":
    return true
}
```

This is a minimal, backwards-compatible change that allows OpenCode to work correctly with Contrabass without affecting other agent integrations.

## Testing

- Built successfully: `go build -o contrabass ./cmd/contrabass`
- The change only affects the success signal detection logic
- No breaking changes to existing agent support

## Related

This is a separate fix from PR #29 (which addresses parts array format). This PR specifically fixes the orchestrator's completion signal recognition for OpenCode.