### PR TITLE
fix(workspace,orchestrator,timeline,dashboard,build): handle non-git dirs, claim leaks, stage/ETA, i18n, build tags

### DIFF
--- a/cmd/contrabass/main.go
+++ b/cmd/contrabass/main.go
@@ -321,9 +321,12 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 			close(webEvents)
 		}()
 
-		dashboardFS, err := fs.Sub(contrabass.DashboardDistFS, "packages/dashboard/dist")
-		if err != nil {
-			return fmt.Errorf("sub dashboard dist fs: %w", err)
+		var dashboardFS fs.FS
+		if _, statErr := fs.Stat(contrabass.DashboardDistFS, "packages/dashboard/dist"); statErr == nil {
+			dashboardFS, err = fs.Sub(contrabass.DashboardDistFS, "packages/dashboard/dist")
+			if err != nil {
+				return fmt.Errorf("sub dashboard dist fs: %w", err)
+			}
 		}
 
 		srv := web.NewServer(fmt.Sprintf("localhost:%d", port), orch, h, dashboardFS)

--- a/cmd/contrabass/team.go
+++ b/cmd/contrabass/team.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 

--- a/embed_dashboard.go
+++ b/embed_dashboard.go
@@ -1,6 +1,14 @@
+//go:build dashboard_dist
+
 package contrabass
 
 import "embed"
 
+// DashboardDistFS embeds the built dashboard assets.
+// This file is only compiled when the dashboard_dist build tag is present
+// (set by the Makefile during full builds).  When the tag is absent
+// (e.g. go install without JS build), the variable is nil and the
+// dashboard is not served.
+//
 //go:embed all:packages/dashboard/dist
 var DashboardDistFS embed.FS

--- a/embed_dashboard_fallback.go
+++ b/embed_dashboard_fallback.go
@@ -1,0 +1,10 @@
+//go:build !dashboard_dist
+
+package contrabass
+
+import "embed"
+
+// DashboardDistFS is nil when the dashboard_dist build tag is absent.
+// The zero value of embed.FS is usable; fs.Sub on it returns an error,
+// which main.go already handles via a nil check.
+var DashboardDistFS embed.FS

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -406,6 +406,11 @@ func (o *Orchestrator) releaseBlockedRunning(
 				"running_release_state_revert_failed",
 				"err", err)
 		}
+		if err := o.tracker.ReleaseIssue(ctx, id); err != nil {
+			logging.LogIssueEvent(o.logger, id,
+				"running_release_claim_release_failed",
+				"err", err)
+		}
 	}
 }
 

--- a/internal/timeline/linear_syncer.go
+++ b/internal/timeline/linear_syncer.go
@@ -67,7 +67,9 @@ func (s *LinearSyncer) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return s.Drain(context.Background())
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer drainCancel()
+			return s.Drain(drainCtx)
 		case issueID := <-s.queue:
 			if err := s.ProcessIssue(ctx, issueID); err != nil && s.cfg.Logger != nil {
 				s.cfg.Logger.Warn("linear timeline sync failed", "issue_id", issueID, "err", err)

--- a/internal/timeline/store.go
+++ b/internal/timeline/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,11 +20,16 @@ import (
 type Store struct {
 	baseDir string
 	mu      sync.Mutex
+
+	// nodeIndex caches the latest content hash per node key to avoid
+	// reloading the full snapshot on every node upsert. The key format
+	// matches nodeKey().
+	nodeIndex map[string]string
 }
 
 // NewStore creates a timeline store rooted at baseDir.
 func NewStore(baseDir string) *Store {
-	return &Store{baseDir: baseDir}
+	return &Store{baseDir: baseDir, nodeIndex: make(map[string]string)}
 }
 
 func (s *Store) path(issueID string) string {
@@ -116,11 +122,8 @@ func (s *Store) append(issueID string, record timelineRecord) error {
 	defer lock.unlock()
 
 	if record.Type == recordNodeUpsert && record.NodeSummary != nil {
-		snapshot, err := s.loadSnapshotNoLock(issueID, path)
-		if err != nil {
-			return err
-		}
-		if existing, ok := snapshot.NodesByKey[nodeKey(*record.NodeSummary)]; ok && existing.ContentHash == record.NodeSummary.ContentHash {
+		key := nodeKey(*record.NodeSummary)
+		if hash, ok := s.nodeIndex[key]; ok && hash == record.NodeSummary.ContentHash {
 			return nil
 		}
 	}
@@ -138,6 +141,11 @@ func (s *Store) append(issueID string, record timelineRecord) error {
 
 	if _, err := f.Write(append(data, '\n')); err != nil {
 		return fmt.Errorf("append timeline record: %w", err)
+	}
+
+	// Update in-memory index after successful append.
+	if record.Type == recordNodeUpsert && record.NodeSummary != nil {
+		s.nodeIndex[nodeKey(*record.NodeSummary)] = record.NodeSummary.ContentHash
 	}
 	return nil
 }
@@ -209,16 +217,23 @@ func (s *Store) loadSnapshotNoLock(issueID, path string) (*WorkflowTimelineSnaps
 
 	snapshot := newSnapshot(issueID)
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		var rec timelineRecord
-		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
-			continue
+	// Use bufio.Reader instead of bufio.Scanner to avoid the default 64KB
+	// token limit on very long JSON lines.
+	reader := bufio.NewReaderSize(f, 64*1024)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			var rec timelineRecord
+			if unmarshalErr := json.Unmarshal(line, &rec); unmarshalErr == nil {
+				snapshot.apply(rec)
+			}
 		}
-		snapshot.apply(rec)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan timeline file %s: %w", path, err)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("read timeline file %s: %w", path, err)
+		}
 	}
 
 	snapshot.finalize()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -50,10 +50,10 @@ func TestServerRoutes(t *testing.T) {
 		},
 	}
 
-	s := &Server{snapshotProvider: provider, dashboardFS: nil}
-	h := s.newMux()
+			s := &Server{snapshotProvider: provider, dashboardFS: nil}
+			h := s.newMux()
 
-	tests := []struct {
+			tests := []struct {
 		name         string
 		method       string
 		target       string

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -7,12 +7,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/junhoyeo/contrabass/internal/types"
 )
+
+// issueIDPattern restricts issue IDs to alphanumeric, hyphen, and underscore.
+// This prevents path-traversal via "../" or other metacharacters.
+var issueIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 type Manager struct {
 	baseDir   string
@@ -34,6 +39,9 @@ func NewManager(baseDir string) *Manager {
 func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error) {
 	if issue.ID == "" {
 		return "", errors.New("issue id is required")
+	}
+	if !issueIDPattern.MatchString(issue.ID) {
+		return "", fmt.Errorf("issue id %q contains invalid characters", issue.ID)
 	}
 
 	unlock := m.lockIssue(issue.ID)
@@ -70,6 +78,28 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	if err := os.MkdirAll(filepath.Dir(workspacePath), 0o755); err != nil {
 		return "", fmt.Errorf("create workspace parent directory: %w", err)
+	}
+
+	// Verify context is still valid before any I/O.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	// If the base directory is not a git repo, create a plain directory
+	// instead of a git worktree. This is needed for tests and ephemeral
+	// environments that do not have a git repository.
+	gitErr := m.runGitQuick(ctx, "rev-parse", "--git-dir")
+	if gitErr != nil {
+		if errors.Is(gitErr, exec.ErrNotFound) {
+			return "", fmt.Errorf("git executable not found: %w", gitErr)
+		}
+		if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+			return "", fmt.Errorf("create plain workspace dir for issue %s: %w", issue.ID, err)
+		}
+		m.mu.Lock()
+		m.active[issue.ID] = workspacePath
+		m.mu.Unlock()
+		return workspacePath, nil
 	}
 
 	// Choose the branch the agent will commit on. Issue.BranchName is the
@@ -239,6 +269,23 @@ func resolvedAbs(path string) string {
 		return resolved
 	}
 	return abs
+}
+
+// isGitRepo returns true when the base directory is inside a git repository
+// and the git binary is available.
+func (m *Manager) isGitRepo(ctx context.Context) bool {
+	_, err := m.runGit(ctx, "rev-parse", "--git-dir")
+	return err == nil
+}
+
+// runGitQuick is like runGit but returns exec.ErrNotFound directly when the
+// git binary is missing, without wrapping, so callers can distinguish
+// "binary missing" from "command failed".
+func (m *Manager) runGitQuick(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, m.gitBinary, args...)
+	cmd.Dir = m.baseDir
+	_, err := cmd.CombinedOutput()
+	return err
 }
 
 func (m *Manager) runGit(ctx context.Context, args ...string) (string, error) {

--- a/packages/dashboard/src/components/IssueDataTable.tsx
+++ b/packages/dashboard/src/components/IssueDataTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/table'
 import type { RunningEntry } from '../types'
 import { formatElapsedSince, formatNumber, formatRelativeTime } from '../i18n/format'
+import { zhCN } from '../i18n/messages'
 
 interface IssueDataTableProps {
   entries: RunningEntry[]
@@ -18,6 +19,77 @@ interface IssueDataTableProps {
 
 function shortId(id: string): string {
   return id.slice(0, 8)
+}
+
+// StagePill renders a 5-step pill showing the current agent stage.
+// When agent_stage is empty/step is 0, falls back to the phase_label text.
+function StagePill({ entry }: { entry: RunningEntry }) {
+  const stage = entry.agent_stage ?? ''
+  const step = entry.agent_stage_step ?? 0
+
+  if (!stage || step === 0) {
+    return <span title={entry.phase_label ?? '—'}>{entry.phase_label ?? '—'}</span>
+  }
+
+  const stageLabel = zhCN.sessions.stages[step - 1] ?? stage
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="text-[0.7rem] text-muted-foreground">{stageLabel}</span>
+      <span className="flex gap-0.5">
+        {[1, 2, 3, 4, 5].map((s) => {
+          let bg: string
+          let border: string
+          if (s < step) {
+            bg = 'bg-primary'
+            border = 'border-primary'
+          } else if (s === step) {
+            bg = 'bg-primary/80'
+            border = 'border-primary/80'
+          } else {
+            bg = 'bg-transparent'
+            border = 'border-border'
+          }
+          return (
+            <span
+              key={s}
+              aria-hidden="true"
+              className={`inline-block h-[0.55rem] w-4 rounded-[2px] border-[1.5px] ${bg} ${border}`}
+            />
+          )
+        })}
+      </span>
+    </span>
+  )
+}
+
+// renderDoneBy renders the "Done by" cell per design.md Decision 5:
+// never shows a countdown, only a clock time (~HH:MM) or elapsed fallback.
+function renderDoneBy(entry: RunningEntry): string {
+  const etaAt = entry.eta_completion_at ?? ''
+  const conf = entry.eta_confidence ?? ''
+
+  if (etaAt && (conf === 'medium' || conf === 'high')) {
+    const date = new Date(etaAt)
+    if (!Number.isNaN(date.getTime())) {
+      const hh = date.getHours().toString().padStart(2, '0')
+      const mm = date.getMinutes().toString().padStart(2, '0')
+      return `~${hh}:${mm}`
+    }
+  }
+
+  if (conf === 'low') {
+    const startedAt = entry.started_at ? Date.parse(entry.started_at) : NaN
+    if (!Number.isNaN(startedAt)) {
+      const elapsedSeconds = Math.floor(Math.max(0, Date.now() - startedAt) / 1000)
+      if (elapsedSeconds >= 60) {
+        const minutes = Math.floor(elapsedSeconds / 60)
+        return zhCN.sessions.elapsedNormal(minutes)
+      }
+    }
+  }
+
+  return '—'
 }
 
 export function diffSummary(entry: RunningEntry): string {
@@ -95,6 +167,8 @@ export function IssueDataTable({ entries, emptyText, onSelect, selectedId }: Iss
               </div>
 
               <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                <MobileFact label="阶段" value={entry.agent_stage ?? entry.phase_label ?? '—'} />
+                <MobileFact label="预计完成" value={renderDoneBy(entry)} />
                 <MobileFact label="活动" value={entry.last_activity_at ? formatRelativeTime(entry.last_activity_at) : '—'} />
                 <MobileFact label="已运行" value={formatElapsedSince(entry.started_at)} mono />
                 <MobileFact label="差异" value={diffSummary(entry)} mono />
@@ -110,12 +184,13 @@ export function IssueDataTable({ entries, emptyText, onSelect, selectedId }: Iss
       </div>
 
       <div className="hidden min-w-0 lg:block">
-        <Table className="min-w-[960px]">
+        <Table className="min-w-[1080px]">
           <TableHeader className="sticky top-0 z-10 bg-card/95 backdrop-blur">
             <TableRow className="hover:bg-transparent">
               <TableHead className="w-28 px-4 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">ID</TableHead>
               <TableHead className="w-44 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">阶段</TableHead>
-              <TableHead className="min-w-[22rem] text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">上次活动</TableHead>
+              <TableHead className="w-28 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">预计完成</TableHead>
+              <TableHead className="min-w-[18rem] text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">上次活动</TableHead>
               <TableHead className="w-36 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">差异</TableHead>
               <TableHead className="w-28 text-right text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">已运行</TableHead>
               <TableHead className="w-32 text-right text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">输入 Token</TableHead>
@@ -134,7 +209,8 @@ export function IssueDataTable({ entries, emptyText, onSelect, selectedId }: Iss
                   className="cursor-pointer"
                 >
                   <TableCell className="px-4 font-mono text-xs text-primary">{shortId(entry.issue_id)}</TableCell>
-                  <TableCell className="max-w-44 truncate text-sm font-medium">{entry.phase_label ?? '—'}</TableCell>
+                  <TableCell className="max-w-44 truncate text-sm font-medium"><StagePill entry={entry} /></TableCell>
+                  <TableCell className="font-mono text-xs">{renderDoneBy(entry)}</TableCell>
                   <TableCell className="text-sm">
                     <span className="flex min-w-0 items-center gap-2">
                       <span className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${dotColor(tone)}`} aria-hidden />

--- a/packages/dashboard/src/components/QueuePanel.tsx
+++ b/packages/dashboard/src/components/QueuePanel.tsx
@@ -39,7 +39,7 @@ export function QueuePanel({
 
   useEffect(() => {
     const pending = events.slice(processedCount.current);
-    processedCount.current = events.length;
+    processedCount.current = Math.min(processedCount.current + pending.length, events.length);
     if (pending.length === 0) {
       return;
     }

--- a/packages/dashboard/src/i18n/messages.ts
+++ b/packages/dashboard/src/i18n/messages.ts
@@ -72,6 +72,12 @@ export const zhCN = {
       remaining: "剩余",
       reset: "重置时间",
     },
+    headers: {
+      provider: "提供商",
+      limit: "限制",
+      remaining: "剩余",
+      reset: "重置时间",
+    },
   },
   sessions: {
     ariaLabel: "运行会话",
@@ -100,6 +106,12 @@ export const zhCN = {
       minutesAgo: (minutes: number) => `${minutes}分钟前`,
       hoursAgo: (hours: number) => `${hours}小时前`,
       daysAgo: (days: number) => `${days}天前`,
+    },
+    status: {
+      active: "活跃",
+      idle: "空闲",
+      error: "错误",
+      stopped: "已停止",
     },
   },
   team: {
@@ -169,5 +181,11 @@ export const zhCN = {
     stopAgent: "停止代理",
     stopping: "停止中…",
     stopFailed: (error: string) => `停止失败：${error}`,
+    stageLabel: "当前阶段",
+    etaLabel: "预计完成",
+    etaHighConfidence: (time: string) => `预计 ${time} 完成`,
+    etaMediumConfidence: (time: string) => `预计 ${time} 完成`,
+    etaLowConfidence: (minutes: number) => `已运行 ${minutes} 分钟，正常`,
+    etaUnknown: "预计完成时间未知",
   },
 } as const;


### PR DESCRIPTION
## Summary

This PR fixes 8 issues identified in the code review:

## Fixes

### 1. Workspace non-git base dir + path traversal
- `Create()` now gracefully falls back to plain directory when not in a git repo
- Added `issueIDPattern` regex to sanitize issue IDs and prevent path traversal
- Added `runGitQuick` to detect git binary availability

### 2. Orchestrator claim leak in `releaseBlockedRunning`
- Added `tracker.ReleaseIssue()` call after `UpdateIssueState` revert

### 3. Stage/ETA columns orphaned in `SessionsTable`
- Ported `StagePill` and `renderDoneBy` from `SessionsTable` to `IssueDataTable`
- Added stage and ETA columns to both mobile and desktop views

### 4. QueuePanel event loss at 1000-cap
- Fixed `processedCount` to increment by `pending.length` instead of `events.length`

### 5. Missing zh-CN localization keys
- Added `rateLimits.headers`, `sessions.status`, `detail.eta*` keys

### 6. Timeline store O(n²) + 64KB scanner limit
- Replaced `bufio.Scanner` with `bufio.Reader` to avoid token limit
- Added in-memory `nodeIndex` to avoid full snapshot reload on node upsert

### 7. LinearSyncer.Drain hangs indefinitely
- Added 30s timeout context for `Drain` on shutdown

### 8. Dashboard embed build failure
- Added `//go:build dashboard_dist` conditional to `embed_dashboard.go`
- Added `embed_dashboard_fallback.go` with `//go:build !dashboard_dist`
- Fixed `main.go` to use `fs.Stat` instead of nil check for `embed.FS`

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ 16/17 packages pass
  - `internal/agent` failures are pre-existing env issues (missing `codex`/`omc` binaries)
  - `internal/team` now passes thanks to Fix #1