### PR TITLE
fix: preserve Codex and MCP contracts

### DIFF
--- a/cmd/contrabass/team.go
+++ b/cmd/contrabass/team.go
@@ -178,7 +178,7 @@ func createRunner(cfg *config.WorkflowConfig, teamName string, logger *slog.Logg
 		// inheriting whatever is in ~/.codex/config.toml. Empty fields are not
 		// injected — codex falls back to its own defaults.
 		runner.ConfigureCodex(agent.CodexRunnerOptions{
-			Model:          cfg.Codex.Model,
+			Model:          cfg.CodexModel(),
 			ApprovalPolicy: cfg.Codex.ApprovalPolicy,
 			Sandbox:        cfg.Codex.Sandbox,
 		})

--- a/cmd/contrabass/team_test.go
+++ b/cmd/contrabass/team_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/junhoyeo/contrabass/internal/agent"
+	"github.com/junhoyeo/contrabass/internal/config"
 	"github.com/junhoyeo/contrabass/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogTeamEventsStopsOnContextCancel(t *testing.T) {
@@ -27,4 +32,20 @@ func TestLogTeamEventsStopsOnContextCancel(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("logTeamEvents did not stop after context cancellation")
 	}
+}
+
+func TestCreateRunnerForwardsLegacyModelToCodex(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		ModelRaw: "openai/gpt-5-codex",
+		Agent:    config.AgentConfig{Type: "codex"},
+	}
+
+	runner, err := createRunner(cfg, "team-test", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, runner.Close()) })
+
+	codexRunner, ok := runner.(*agent.CodexRunner)
+	require.True(t, ok)
+	options := reflect.ValueOf(codexRunner).Elem().FieldByName("options")
+	assert.Equal(t, "openai/gpt-5-codex", options.FieldByName("Model").String())
 }

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -150,7 +150,7 @@ func Resolve(cfg *WorkflowConfig) (*ResolvedConfig, error) {
 	add("hooks.before_remove", cfg.HookBeforeRemove(), sourceFor(cfg.Hooks.BeforeRemove != ""), "hooks.before_remove", StartupOnly, false, "parsed but hook execution is not implemented")
 
 	add("codex.binary_path", cfg.CodexBinaryPath(), sourceFor(cfg.Codex.BinaryPath != ""), "codex.binary_path", StartupOnly, false, "runner process is constructed at startup")
-	add("codex.model", cfg.CodexModel(), codexModelSource(cfg), codexModelSourcePath(cfg), Reloadable, false, "")
+	add("codex.model", cfg.CodexModel(), codexModelSource(cfg), codexModelSourcePath(cfg), StartupOnly, false, "runner process is constructed at startup")
 	add("codex.approval_policy", cfg.CodexApprovalPolicy(), sourceFor(cfg.Codex.ApprovalPolicy != ""), "codex.approval_policy", StartupOnly, false, "runner process is constructed at startup")
 	add("codex.sandbox", cfg.CodexSandbox(), sourceFor(cfg.Codex.Sandbox != ""), "codex.sandbox", StartupOnly, false, "runner process is constructed at startup")
 	add("agent.type", cfg.AgentType(), sourceFor(cfg.Agent.Type != ""), "agent.type", StartupOnly, false, "runner implementation is selected at startup")

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -38,6 +38,7 @@ func TestResolveConfigBuildsCanonicalRuntimeValues(t *testing.T) {
 	assert.Equal(t, ConfigSourceDeprecatedAlias, resolved.Metadata["polling.interval_ms"].Source)
 	assert.Equal(t, StartupOnly, resolved.Metadata["polling.interval_ms"].ReloadPolicy)
 	assert.Equal(t, StartupOnly, resolved.Metadata["tracker.type"].ReloadPolicy)
+	assert.Equal(t, StartupOnly, resolved.Metadata["codex.model"].ReloadPolicy)
 	assert.Contains(t, resolved.Warnings, "codex.model falls back to model; configure codex.model to make the runner model explicit")
 	assert.Contains(t, resolved.Warnings, "tracker.project_url falls back to project_url; configure tracker.project_url to make tracker scope explicit")
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -23,6 +23,13 @@ type SnapshotProvider interface {
 	Snapshot() orchestrator.StateSnapshot
 }
 
+// MCPDashboardSnapshotProvider reports whether the generic orchestrator
+// snapshot tool is meaningful for this server's current snapshot source.
+// Providers that do not implement it retain the legacy supported behavior.
+type MCPDashboardSnapshotProvider interface {
+	SupportsMCPDashboardSnapshot() bool
+}
+
 // AgentStopper is implemented by the orchestrator so the dashboard can
 // terminate a running agent via the stop endpoint without coupling the
 // HTTP layer to process-lifecycle details.

--- a/internal/web/streamable_http.go
+++ b/internal/web/streamable_http.go
@@ -145,7 +145,7 @@ func (s *Server) handleStreamableHTTPPost(w http.ResponseWriter, r *http.Request
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
-		writeJSONRPCResult(w, http.StatusOK, req.ID, mcpToolsListResult())
+		writeJSONRPCResult(w, http.StatusOK, req.ID, s.mcpToolsListResult())
 	case mcpMethodToolsCall:
 		if !acceptsResponseType(r, "application/json") {
 			writeJSONRPCError(w, http.StatusNotAcceptable, req.ID, -32000, "tools/call requires Accept: application/json")
@@ -226,10 +226,11 @@ func mcpInitializeResult() map[string]interface{} {
 	}
 }
 
-func mcpToolsListResult() map[string]interface{} {
-	return map[string]interface{}{
-		"tools": []map[string]interface{}{
-			{
+func (s *Server) mcpToolsListResult() map[string]interface{} {
+	tools := []map[string]interface{}{}
+	if s.supportsMCPDashboardSnapshot() {
+		tools = append(tools,
+			map[string]interface{}{
 				"name":        mcpToolDashboardSnapshot,
 				"title":       "Contrabass dashboard snapshot",
 				"description": "Return the current Contrabass dashboard state snapshot as JSON.",
@@ -238,8 +239,14 @@ func mcpToolsListResult() map[string]interface{} {
 					"additionalProperties": false,
 				},
 			},
-		},
+		)
 	}
+	return map[string]interface{}{"tools": tools}
+}
+
+func (s *Server) supportsMCPDashboardSnapshot() bool {
+	provider, ok := s.snapshotProvider.(MCPDashboardSnapshotProvider)
+	return !ok || provider.SupportsMCPDashboardSnapshot()
 }
 
 func (s *Server) handleMCPToolCall(w http.ResponseWriter, req streamableHTTPRequest) {
@@ -253,6 +260,10 @@ func (s *Server) handleMCPToolCall(w http.ResponseWriter, req streamableHTTPRequ
 
 	switch params.Name {
 	case mcpToolDashboardSnapshot:
+		if !s.supportsMCPDashboardSnapshot() {
+			writeJSONRPCError(w, http.StatusOK, req.ID, -32602, "unknown tool")
+			return
+		}
 		if s.snapshotProvider == nil {
 			writeJSONRPCError(w, http.StatusOK, req.ID, -32000, "server is not ready")
 			return

--- a/internal/web/streamable_http_test.go
+++ b/internal/web/streamable_http_test.go
@@ -158,6 +158,28 @@ func TestHandleMCPInitializeAndTools(t *testing.T) {
 	assert.Contains(t, textContent["text"], `"stats"`)
 }
 
+func TestMCPHidesOrchestratorSnapshotToolForTeamProvider(t *testing.T) {
+	s := &Server{snapshotProvider: NewTeamSnapshotProvider(), dashboardFS: nil}
+	token, _, err := s.createMCPToken(time.Now().UTC())
+	require.NoError(t, err)
+	h := s.newMux()
+
+	tools := mustPostMCPJSONRPC(t, h, token, `{"jsonrpc":"2.0","id":"tools-1","method":"tools/list"}`)
+	assert.Equal(t, http.StatusOK, tools.Code)
+	toolsMessage := mustJSONRPCMessage(t, tools)
+	toolsResult, ok := toolsMessage.Result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Empty(t, toolsResult["tools"])
+
+	call := mustPostMCPJSONRPC(t, h, token, `{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"contrabass.dashboard_snapshot","arguments":{}}}`)
+	assert.Equal(t, http.StatusOK, call.Code)
+	var callMessage streamableHTTPMessage
+	require.NoError(t, json.Unmarshal(call.Body.Bytes(), &callMessage))
+	require.NotNil(t, callMessage.Error)
+	assert.Equal(t, -32602, callMessage.Error.Code)
+	assert.Equal(t, "unknown tool", callMessage.Error.Message)
+}
+
 func TestHandleMCPMethodsRequireTokenProtectedMCPPath(t *testing.T) {
 	provider := fakeSnapshotProvider{snapshot: orchestrator.StateSnapshot{
 		Stats:       orchestrator.Stats{Running: 1},

--- a/internal/web/team.go
+++ b/internal/web/team.go
@@ -11,3 +11,9 @@ func NewTeamSnapshotProvider() *TeamSnapshotProvider {
 func (p *TeamSnapshotProvider) Snapshot() orchestrator.StateSnapshot {
 	return orchestrator.StateSnapshot{}
 }
+
+// SupportsMCPDashboardSnapshot reports false because a team dashboard is
+// event-driven and does not have an orchestrator StateSnapshot to expose.
+func (p *TeamSnapshotProvider) SupportsMCPDashboardSnapshot() bool {
+	return false
+}

--- a/internal/web/team_test.go
+++ b/internal/web/team_test.go
@@ -11,12 +11,14 @@ import (
 )
 
 var _ SnapshotProvider = (*TeamSnapshotProvider)(nil)
+var _ MCPDashboardSnapshotProvider = (*TeamSnapshotProvider)(nil)
 
 func TestTeamSnapshotProviderSnapshotReturnsEmptySnapshot(t *testing.T) {
 	provider := NewTeamSnapshotProvider()
 	snapshot := provider.Snapshot()
 
 	assert.Equal(t, orchestrator.StateSnapshot{}, snapshot)
+	assert.False(t, provider.SupportsMCPDashboardSnapshot())
 }
 
 func TestNewServerWithTeamSnapshotProvider(t *testing.T) {


### PR DESCRIPTION
Fixes regressions introduced by #41.

- forwards the established top-level `model` alias to Codex runners
- classifies `codex.model` as startup-only, matching runner construction
- hides the orchestrator snapshot MCP tool when team mode cannot provide one

Validation:

- `go test ./cmd/contrabass ./internal/config ./internal/web`
- `go test ./internal/agent -count=1`
- `go vet ./cmd/contrabass ./internal/config ./internal/web`

The complete Go suite was also run; three existing 2-second Codex handshake tests timed out under full-suite load and passed when rerun as the complete `internal/agent` package.