### PR TITLE
fix: clarify Nix package and release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,6 @@ jobs:
       - name: Build embedded dashboard
         run: make build-dashboard
 
-      - name: Patch flake.nix version
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          sed -i "s/version = \".*\";/version = \"${version}\";/" flake.nix
-          sed -i "s/-X main.version=.*\"/-X main.version=${version}\"/" flake.nix
-          git add flake.nix
-          git commit -m "chore(release): bump flake.nix to ${GITHUB_REF_NAME}" || true
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ nix profile install github:junhoyeo/contrabass
 nix develop github:junhoyeo/contrabass
 ```
 
+The Nix package is a headless CLI build: it does not embed the web dashboard.
+Use a source build (`bun install && make build`) when you need the `--port`
+dashboard server.
+
 For NixOS system-wide installation, add to your configuration:
 
 ```nix

--- a/cmd/contrabass/team_root.go
+++ b/cmd/contrabass/team_root.go
@@ -90,14 +90,17 @@ func runTeamExecutionApp(
 }
 
 func runTeamExecutionWebServer(ctx context.Context, logger *log.Logger, port int) (chan<- web.WebEvent, error) {
+	dashboardFS, err := fs.Sub(contrabass.DashboardDistFS, "packages/dashboard/dist")
+	if err != nil {
+		return nil, fmt.Errorf("web dashboard assets are unavailable in this build; rebuild with the dashboard_dist tag: %w", err)
+	}
+	if _, err := fs.Stat(dashboardFS, "index.html"); err != nil {
+		return nil, fmt.Errorf("web dashboard assets are unavailable in this build; rebuild with the dashboard_dist tag: %w", err)
+	}
+
 	webEvents := make(chan web.WebEvent, 256)
 	h := hub.NewHub(webEvents)
 	go h.Run(ctx)
-
-	dashboardFS, err := fs.Sub(contrabass.DashboardDistFS, "packages/dashboard/dist")
-	if err != nil {
-		return nil, fmt.Errorf("sub dashboard dist fs: %w", err)
-	}
 
 	provider := web.NewTeamSnapshotProvider()
 	srv := web.NewServer(fmt.Sprintf("localhost:%d", port), provider, h, dashboardFS)

--- a/cmd/contrabass/team_root_test.go
+++ b/cmd/contrabass/team_root_test.go
@@ -164,6 +164,15 @@ Prompt.
 	}
 }
 
+func TestRunTeamExecutionWebServerExplainsMissingDashboardAssets(t *testing.T) {
+	webEvents, err := runTeamExecutionWebServer(context.Background(), nil, 0)
+
+	require.Error(t, err)
+	assert.Nil(t, webEvents)
+	assert.ErrorContains(t, err, "web dashboard assets are unavailable in this build")
+	assert.ErrorContains(t, err, "dashboard_dist")
+}
+
 func TestPublishTeamWebEventGuaranteesCriticalEvents(t *testing.T) {
 	ctx := context.Background()
 	webEvents := make(chan web.WebEvent, 1)

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           ldflags = [
             "-s"
             "-w"
-            "-X main.version=${version}"
+            "-X main.version=${self.shortRev or "dirty"}"
             "-X main.commit=${self.shortRev or "dirty"}"
           ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         contrabass = pkgs.buildGoModule {
           pname = "contrabass";
-          version = "0.4.1";
+          version = self.shortRev or "dirty";
           src = ./.;
 
           # Empty string disables vendor hash checking
@@ -28,7 +28,7 @@
           ldflags = [
             "-s"
             "-w"
-            "-X main.version=0.4.1"
+            "-X main.version=${version}"
             "-X main.commit=${self.shortRev or "dirty"}"
           ];
 


### PR DESCRIPTION
Fixes follow-up issues found in #38.

- derives flake package metadata from the evaluated revision instead of an unpushed release-runner mutation
- documents that the current Nix package is a headless CLI build
- makes `--port` fail with an actionable dashboard-assets error, before starting the event hub

Validation:

- `go test -p 1 ./... -count=1`
- `go vet ./...`

Not tested locally: `nix build` and `nix flake check` (Nix is unavailable in this environment). Nix CI will validate the flake build.