### PR TITLE
test(agent): stabilize Codex protocol shutdown fixture

### DIFF
--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -959,7 +959,13 @@ func TestCodexHelperProcess(t *testing.T) {
 				return
 			case "sequence":
 				writeJSON(t, writer, map[string]interface{}{"method": "helper/sequence", "params": map[string]interface{}{"methods": methods}})
-				writeJSON(t, writer, map[string]interface{}{"method": "turn/completed", "params": map[string]interface{}{}})
+				// Keep the helper alive until the test exercises runner.Stop. If
+				// this exits immediately, the stream goroutine can unregister the
+				// process before Stop observes it.
+				sigCh := make(chan os.Signal, 1)
+				signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+				defer signal.Stop(sigCh)
+				<-sigCh
 				return
 			case "events":
 				writeJSON(t, writer, map[string]interface{}{"method": "item/commandExecution/requestApproval", "params": map[string]interface{}{"command": "ls"}})


### PR DESCRIPTION
## Summary

Keep the protocol-sequence test fixture alive until `runner.Stop` sends its interrupt.

The helper previously exited after emitting its first event. The stream goroutine could then remove the process from the runner before the test called `Stop`, producing an intermittent `codex process already stopped` failure.

## Scope

Test fixture only; production runner behavior is unchanged.

## Verification

- `go test ./internal/agent -run ^TestCodexProtocolSequence$ -count=25`
- `go test -race ./internal/agent -run ^TestCodexProtocolSequence$ -count=10`
- `go test -p 1 ./... -count=1`
- `go vet ./...`