### PR TITLE
fix(project): make dashboard release hook executable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,8 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - cd packages/dashboard && bun run build && touch dist/.gitkeep
+    - bun run --cwd packages/dashboard build
+    - touch packages/dashboard/dist/.gitkeep
 
 builds:
   - main: ./cmd/contrabass


### PR DESCRIPTION
## Summary

Replace the shell-based dashboard GoReleaser hook with two executable commands.

GoReleaser v2 runs hooks directly, so `cd packages/dashboard && ...` failed because `cd` is a shell builtin. This blocked the `v0.5.0` release before artifacts were created.

## Verification

- `go test -p 1 ./... -count=1`
- `go vet ./...`
- `git diff --check`
- inspected failed release run 29498124212

The local dashboard dependency tree has pre-existing duplicate Vite types; the original release run passed its clean dashboard build, so the post-merge tag release is the authoritative clean-environment validation.