### PR TITLE
fix(tracker): assignee-aware claim safety across Linear/GitHub/local adapters

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -223,8 +223,8 @@ func (o *Orchestrator) runCycle(ctx context.Context, supervisor *errgroup.Group,
 	openIDs := buildOpenIDSet(issues)
 
 	o.dispatchReadyBackoff(ctx, supervisorCtxOr(ctx), cfg, issuesByID, supervisor, runSignals)
-	o.recoverOrphanedClaims(issues)
-	o.dispatchUnclaimedIssues(ctx, supervisorCtxOr(ctx), cfg, issues, openIDs, supervisor, runSignals)
+	recoveredAttempts := o.recoverOrphanedClaims(issues)
+	o.dispatchUnclaimedIssues(ctx, supervisorCtxOr(ctx), cfg, issues, openIDs, recoveredAttempts, supervisor, runSignals)
 	o.releaseBlockedRunning(ctx, issuesByID, openIDs)
 	o.emitStatusUpdate()
 }
@@ -304,6 +304,7 @@ func (o *Orchestrator) dispatchUnclaimedIssues(
 	cfg *config.WorkflowConfig,
 	issues []types.Issue,
 	openIDs map[string]struct{},
+	recoveredAttempts map[string]int,
 	supervisor *errgroup.Group,
 	runSignals chan<- runSignal,
 ) {
@@ -324,7 +325,11 @@ func (o *Orchestrator) dispatchUnclaimedIssues(
 			continue
 		}
 
-		o.dispatchIssue(ctx, watchCtx, cfg, issue, 1, supervisor, runSignals)
+		attemptNumber := 1
+		if recoveredAttempt, recovered := recoveredAttempts[issue.ID]; recovered {
+			attemptNumber = recoveredAttempt
+		}
+		o.dispatchIssue(ctx, watchCtx, cfg, issue, attemptNumber, supervisor, runSignals)
 	}
 }
 
@@ -337,7 +342,8 @@ func (o *Orchestrator) dispatchUnclaimedIssues(
 // The orphan_claim_recovered log event is emitted at most once per issue per
 // orchestrator lifetime (tracked via recoveredSet) to prevent log spam when
 // dispatch is deferred across multiple ticks (e.g. max concurrency reached).
-func (o *Orchestrator) recoverOrphanedClaims(issues []types.Issue) {
+func (o *Orchestrator) recoverOrphanedClaims(issues []types.Issue) map[string]int {
+	recoveredAttempts := make(map[string]int)
 	o.mu.Lock()
 	managed := make(map[string]struct{}, len(o.running)+len(o.paused))
 	for id := range o.running {
@@ -356,6 +362,10 @@ func (o *Orchestrator) recoverOrphanedClaims(issues []types.Issue) {
 			continue
 		}
 		issues[i].State = types.Unclaimed
+		// A durable tracker claim proves that a prior run already started. The
+		// replacement agent cannot resume its dead process, but it must be
+		// represented as a recovery attempt rather than a new attempt 1.
+		recoveredAttempts[issue.ID] = 2
 
 		o.mu.Lock()
 		_, alreadyLogged := o.recoveredSet[issue.ID]
@@ -369,6 +379,8 @@ func (o *Orchestrator) recoverOrphanedClaims(issues []types.Issue) {
 				"identifier", issue.Identifier)
 		}
 	}
+
+	return recoveredAttempts
 }
 
 // releaseBlockedRunning re-evaluates BlockedBy for every currently-managed

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1938,9 +1938,10 @@ func TestRecoverOrphanedClaims_OrphanOverriddenAndLogged(t *testing.T) {
 		{ID: "ISS-ORPHAN", Identifier: "ISS-ORPHAN", State: types.Claimed},
 	}
 
-	orch.recoverOrphanedClaims(issues)
+	recoveredAttempts := orch.recoverOrphanedClaims(issues)
 
 	assert.Equal(t, types.Unclaimed, issues[0].State, "orphaned Claimed issue must be overridden to Unclaimed")
+	assert.Equal(t, map[string]int{"ISS-ORPHAN": 2}, recoveredAttempts)
 	assert.Contains(t, buf.String(), "orphan_claim_recovered")
 	assert.Contains(t, buf.String(), "ISS-ORPHAN")
 }

--- a/internal/tracker/flock.go
+++ b/internal/tracker/flock.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,32 @@ func (l *fileLock) Lock() error {
 	}
 
 	return nil
+}
+
+// TryLock acquires an exclusive lock without waiting. It returns false, nil
+// when another process currently holds the lock.
+func (l *fileLock) TryLock() (bool, error) {
+	dir := filepath.Dir(l.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("create lock dir: %w", err)
+	}
+
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return false, fmt.Errorf("open lock file %s: %w", l.path, err)
+	}
+
+	l.file = f
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		l.file = nil
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return false, nil
+		}
+		return false, fmt.Errorf("flock %s: %w", l.path, err)
+	}
+
+	return true, nil
 }
 
 // Unlock releases the lock.

--- a/internal/tracker/flock.go
+++ b/internal/tracker/flock.go
@@ -1,0 +1,66 @@
+package tracker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// fileLock provides cross-process advisory locking using flock(2). The local
+// board is mutated by the daemon and the `contrabass board`/`team` CLIs from
+// separate processes sharing one BoardDir; the in-process sync.Mutex alone
+// cannot stop two processes from racing the manifest read-modify-write and
+// minting duplicate issue IDs. Mirrors internal/team.FileLock, kept
+// package-local to avoid a tracker→team dependency.
+type fileLock struct {
+	path string
+	file *os.File
+}
+
+func newFileLock(path string) *fileLock {
+	return &fileLock{path: path + ".lock"}
+}
+
+// Lock acquires an exclusive lock, blocking until available.
+func (l *fileLock) Lock() error {
+	dir := filepath.Dir(l.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create lock dir: %w", err)
+	}
+
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open lock file %s: %w", l.path, err)
+	}
+
+	l.file = f
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		l.file = nil
+		return fmt.Errorf("flock %s: %w", l.path, err)
+	}
+
+	return nil
+}
+
+// Unlock releases the lock.
+func (l *fileLock) Unlock() error {
+	if l.file == nil {
+		return nil
+	}
+
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
+		_ = l.file.Close()
+		l.file = nil
+		return fmt.Errorf("funlock %s: %w", l.path, err)
+	}
+
+	err := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return fmt.Errorf("close lock file %s: %w", l.path, err)
+	}
+
+	return nil
+}

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -154,7 +154,7 @@ func (c *GitHubClient) ClaimIssue(ctx context.Context, issueID string) error {
 	}
 
 	path := fmt.Sprintf("/repos/%s/%s/issues/%s/assignees", c.owner, c.repo, issueID)
-	_, _, statusCode, err := c.doRequestWithStatus(ctx, http.MethodPost, path, payload)
+	body, _, statusCode, err := c.doRequestWithStatus(ctx, http.MethodPost, path, payload)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,25 @@ func (c *GitHubClient) ClaimIssue(ctx context.Context, issueID string) error {
 		return fmt.Errorf("github API error: expected status 201, got %d", statusCode)
 	}
 
-	return nil
+	// GitHub returns 201 even when it silently ignores an assignee the token
+	// user cannot assign (no push/triage access, or an unknown login). Verify
+	// the claim actually landed so the orchestrator doesn't dispatch an issue
+	// it never owned.
+	var updated githubIssue
+	if err := json.Unmarshal(body, &updated); err != nil {
+		// Response shape changed under us — the 201 already signalled intent,
+		// so don't fail the claim over an unparseable body.
+		return nil
+	}
+	for _, user := range updated.Assignees {
+		if user.Login == c.assignee {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"github accepted the assignee request but %q is not among the issue's assignees (does the token user have triage access to %s/%s?)",
+		c.assignee, c.owner, c.repo,
+	)
 }
 
 func (c *GitHubClient) ReleaseIssue(ctx context.Context, issueID string) error {

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -88,10 +88,15 @@ type githubIssue struct {
 	Body        string                 `json:"body"`
 	State       string                 `json:"state"`
 	Labels      []githubIssueLabel     `json:"labels"`
+	Assignees   []githubUser           `json:"assignees"`
 	HTMLURL     string                 `json:"html_url"`
 	CreatedAt   string                 `json:"created_at"`
 	UpdatedAt   string                 `json:"updated_at"`
 	PullRequest map[string]interface{} `json:"pull_request"`
+}
+
+type githubUser struct {
+	Login string `json:"login"`
 }
 
 type githubIssueLabel struct {
@@ -123,6 +128,9 @@ func (c *GitHubClient) FetchIssues(ctx context.Context) ([]types.Issue, error) {
 
 		for _, item := range pageItems {
 			if item.PullRequest != nil {
+				continue
+			}
+			if c.isAssignedToOther(item) {
 				continue
 			}
 			issues = append(issues, c.normalizeIssue(item))
@@ -320,12 +328,30 @@ func (c *GitHubClient) normalizeIssue(item githubIssue) types.Issue {
 
 	blockedBy := parseDependencies(item.Body)
 
+	// Preserve the claim in the normalized state when the issue is already
+	// assigned to the configured assignee. Hardcoding Unclaimed here would make
+	// the bot's own in-flight issues look freshly unclaimed after a restart, so
+	// they would be re-dispatched from attempt 1 instead of going through
+	// orphan-claim recovery. Mirrors the Linear adapter's started→Claimed
+	// mapping.
+	assigneeLogins := make([]string, 0, len(item.Assignees))
+	state := types.Unclaimed
+	for _, user := range item.Assignees {
+		if user.Login == "" {
+			continue
+		}
+		assigneeLogins = append(assigneeLogins, user.Login)
+		if c.assignee != "" && user.Login == c.assignee {
+			state = types.Claimed
+		}
+	}
+
 	return types.Issue{
 		ID:            numberString,
 		Identifier:    fmt.Sprintf("%s/%s#%d", c.owner, c.repo, item.Number),
 		Title:         item.Title,
 		Description:   item.Body,
-		State:         types.Unclaimed,
+		State:         state,
 		Priority:      0,
 		Labels:        labels,
 		URL:           item.HTMLURL,
@@ -335,8 +361,28 @@ func (c *GitHubClient) normalizeIssue(item githubIssue) types.Issue {
 		CreatedAt:     createdAt,
 		UpdatedAt:     updatedAt,
 		TrackerMeta: map[string]interface{}{
-			"github_node_id": item.NodeID,
-			"github_state":   item.State,
+			"github_node_id":   item.NodeID,
+			"github_state":     item.State,
+			"github_assignees": assigneeLogins,
 		},
 	}
+}
+
+// isAssignedToOther reports whether the issue is assigned exclusively to
+// users other than the configured assignee. Such issues belong to humans (or
+// other bots) and must not be dispatched or "recovered" by orphan-claim
+// recovery — the POST /assignees claim is additive, so claiming them would
+// silently succeed and start an agent on someone else's work. When no
+// assignee is configured, ownership cannot be established and nothing is
+// filtered.
+func (c *GitHubClient) isAssignedToOther(item githubIssue) bool {
+	if c.assignee == "" || len(item.Assignees) == 0 {
+		return false
+	}
+	for _, user := range item.Assignees {
+		if user.Login == c.assignee {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -53,6 +53,9 @@ func NewGitHubClient(cfg GitHubConfig) (*GitHubClient, error) {
 	if strings.TrimSpace(cfg.Repo) == "" {
 		return nil, errors.New("github repo required")
 	}
+	if strings.TrimSpace(cfg.Assignee) == "" {
+		return nil, errors.New("github assignee required")
+	}
 
 	endpoint := cfg.Endpoint
 	if endpoint == "" {
@@ -74,7 +77,7 @@ func NewGitHubClient(cfg GitHubConfig) (*GitHubClient, error) {
 		owner:      cfg.Owner,
 		repo:       cfg.Repo,
 		labels:     cfg.Labels,
-		assignee:   cfg.Assignee,
+		assignee:   strings.TrimSpace(cfg.Assignee),
 		endpoint:   strings.TrimSuffix(endpoint, "/"),
 		httpClient: httpClient,
 		pageSize:   pageSize,
@@ -169,12 +172,10 @@ func (c *GitHubClient) ClaimIssue(ctx context.Context, issueID string) error {
 	// it never owned.
 	var updated githubIssue
 	if err := json.Unmarshal(body, &updated); err != nil {
-		// Response shape changed under us — the 201 already signalled intent,
-		// so don't fail the claim over an unparseable body.
-		return nil
+		return fmt.Errorf("decode GitHub claim response: %w", err)
 	}
 	for _, user := range updated.Assignees {
-		if user.Login == c.assignee {
+		if strings.EqualFold(user.Login, c.assignee) {
 			return nil
 		}
 	}
@@ -359,7 +360,7 @@ func (c *GitHubClient) normalizeIssue(item githubIssue) types.Issue {
 			continue
 		}
 		assigneeLogins = append(assigneeLogins, user.Login)
-		if c.assignee != "" && user.Login == c.assignee {
+		if strings.EqualFold(user.Login, c.assignee) {
 			state = types.Claimed
 		}
 	}
@@ -386,21 +387,18 @@ func (c *GitHubClient) normalizeIssue(item githubIssue) types.Issue {
 	}
 }
 
-// isAssignedToOther reports whether the issue is assigned exclusively to
-// users other than the configured assignee. Such issues belong to humans (or
-// other bots) and must not be dispatched or "recovered" by orphan-claim
-// recovery — the POST /assignees claim is additive, so claiming them would
-// silently succeed and start an agent on someone else's work. When no
-// assignee is configured, ownership cannot be established and nothing is
-// filtered.
+// isAssignedToOther reports whether any assignee is not the configured bot.
+// GitHub's additive assignment API makes a co-assigned issue unsafe too: a
+// human's assignment must keep the issue out of the dispatch queue even when
+// the bot is also listed. GitHub logins are case-insensitive.
 func (c *GitHubClient) isAssignedToOther(item githubIssue) bool {
-	if c.assignee == "" || len(item.Assignees) == 0 {
+	if len(item.Assignees) == 0 {
 		return false
 	}
 	for _, user := range item.Assignees {
-		if user.Login == c.assignee {
-			return false
+		if !strings.EqualFold(user.Login, c.assignee) {
+			return true
 		}
 	}
-	return true
+	return false
 }

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -147,6 +147,71 @@ func TestGitHubFetchIssues_ParsesDependencies(t *testing.T) {
 	assert.Equal(t, []string{"10", "11", "9"}, issues[2].BlockedBy)
 }
 
+// TestGitHubFetchIssues_AssigneeClaimSafety exercises the claim-safety rules:
+// issues assigned exclusively to other users never reach the orchestrator
+// (the additive POST /assignees claim would silently hijack them), and issues
+// already assigned to the configured assignee come back Claimed — not
+// hardcoded Unclaimed — so a restart routes them through orphan-claim
+// recovery instead of re-dispatching in-flight work from attempt 1.
+func TestGitHubFetchIssues_AssigneeClaimSafety(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondGitHubJSON(w, http.StatusOK, []interface{}{
+			map[string]interface{}{
+				"number": 1,
+				"title":  "Unassigned",
+				"body":   "",
+				"state":  "open",
+			},
+			map[string]interface{}{
+				"number": 2,
+				"title":  "Assigned to bot",
+				"body":   "",
+				"state":  "open",
+				"assignees": []interface{}{
+					map[string]interface{}{"login": "bot-user"},
+				},
+			},
+			map[string]interface{}{
+				"number": 3,
+				"title":  "Assigned to a human",
+				"body":   "",
+				"state":  "open",
+				"assignees": []interface{}{
+					map[string]interface{}{"login": "human-dev"},
+				},
+			},
+			map[string]interface{}{
+				"number": 4,
+				"title":  "Assigned to bot and a human",
+				"body":   "",
+				"state":  "open",
+				"assignees": []interface{}{
+					map[string]interface{}{"login": "human-dev"},
+					map[string]interface{}{"login": "bot-user"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(t, server.URL) // configured with Assignee "bot-user"
+	issues, err := client.FetchIssues(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, issues, 3)
+
+	assert.Equal(t, "1", issues[0].ID)
+	assert.Equal(t, types.Unclaimed, issues[0].State)
+	assert.Equal(t, []string{}, issues[0].TrackerMeta["github_assignees"])
+
+	assert.Equal(t, "2", issues[1].ID)
+	assert.Equal(t, types.Claimed, issues[1].State)
+	assert.Equal(t, []string{"bot-user"}, issues[1].TrackerMeta["github_assignees"])
+
+	assert.Equal(t, "4", issues[2].ID)
+	assert.Equal(t, types.Claimed, issues[2].State)
+}
+
 func TestGitHubFetchIssues_FiltersPullRequests(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondGitHubJSON(w, http.StatusOK, []interface{}{

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -168,7 +168,7 @@ func TestGitHubFetchIssues_AssigneeClaimSafety(t *testing.T) {
 				"body":   "",
 				"state":  "open",
 				"assignees": []interface{}{
-					map[string]interface{}{"login": "bot-user"},
+					map[string]interface{}{"login": "BOT-USER"},
 				},
 			},
 			map[string]interface{}{
@@ -198,7 +198,7 @@ func TestGitHubFetchIssues_AssigneeClaimSafety(t *testing.T) {
 	issues, err := client.FetchIssues(context.Background())
 
 	require.NoError(t, err)
-	require.Len(t, issues, 3)
+	require.Len(t, issues, 2)
 
 	assert.Equal(t, "1", issues[0].ID)
 	assert.Equal(t, types.Unclaimed, issues[0].State)
@@ -206,10 +206,7 @@ func TestGitHubFetchIssues_AssigneeClaimSafety(t *testing.T) {
 
 	assert.Equal(t, "2", issues[1].ID)
 	assert.Equal(t, types.Claimed, issues[1].State)
-	assert.Equal(t, []string{"bot-user"}, issues[1].TrackerMeta["github_assignees"])
-
-	assert.Equal(t, "4", issues[2].ID)
-	assert.Equal(t, types.Claimed, issues[2].State)
+	assert.Equal(t, []string{"BOT-USER"}, issues[1].TrackerMeta["github_assignees"])
 }
 
 func TestGitHubFetchIssues_FiltersPullRequests(t *testing.T) {
@@ -390,6 +387,7 @@ func TestGitHubClaimIssue(t *testing.T) {
 		wantErr    bool
 	}{
 		{name: "happy path", statusCode: http.StatusCreated, respBody: issueWithAssignees("bot-user"), wantErr: false},
+		{name: "canonical login casing accepted", statusCode: http.StatusCreated, respBody: issueWithAssignees("BOT-USER"), wantErr: false},
 		{name: "assignee silently ignored", statusCode: http.StatusCreated, respBody: issueWithAssignees(), wantErr: true},
 		{name: "response without assignees rejected", statusCode: http.StatusCreated, respBody: map[string]interface{}{"ok": true}, wantErr: true},
 		{name: "wrong success status", statusCode: http.StatusOK, wantErr: true},
@@ -427,6 +425,31 @@ func TestGitHubClaimIssue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGitHubClaimIssue_RejectsMalformedVerificationResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `not-json`)
+	}))
+	defer server.Close()
+
+	client := testGitHubClient(t, server.URL)
+	err := client.ClaimIssue(context.Background(), "42")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode GitHub claim response")
+}
+
+func TestNewGitHubClient_RequiresAssignee(t *testing.T) {
+	_, err := NewGitHubClient(GitHubConfig{
+		APIToken: "ghp_test_token",
+		Owner:    "octocat",
+		Repo:     "hello-world",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "github assignee required")
 }
 
 func TestGitHubReleaseIssue(t *testing.T) {

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -371,13 +371,27 @@ func TestGitHubFetchIssues_LabelsFilter(t *testing.T) {
 }
 
 func TestGitHubClaimIssue(t *testing.T) {
+	// GitHub answers POST /assignees with 201 and the updated issue. It also
+	// returns 201 when it silently IGNORES an assignee the token user cannot
+	// assign — the "silently ignored" case pins that ClaimIssue detects this
+	// instead of letting the orchestrator dispatch an issue it never owned.
+	issueWithAssignees := func(logins ...string) map[string]interface{} {
+		assignees := make([]interface{}, 0, len(logins))
+		for _, login := range logins {
+			assignees = append(assignees, map[string]interface{}{"login": login})
+		}
+		return map[string]interface{}{"number": 42, "assignees": assignees}
+	}
+
 	tests := []struct {
-		name         string
-		statusCode   int
-		wantErr      bool
-		containsPath string
+		name       string
+		statusCode int
+		respBody   map[string]interface{}
+		wantErr    bool
 	}{
-		{name: "happy path", statusCode: http.StatusCreated, wantErr: false},
+		{name: "happy path", statusCode: http.StatusCreated, respBody: issueWithAssignees("bot-user"), wantErr: false},
+		{name: "assignee silently ignored", statusCode: http.StatusCreated, respBody: issueWithAssignees(), wantErr: true},
+		{name: "response without assignees rejected", statusCode: http.StatusCreated, respBody: map[string]interface{}{"ok": true}, wantErr: true},
 		{name: "wrong success status", statusCode: http.StatusOK, wantErr: true},
 		{name: "http error", statusCode: http.StatusInternalServerError, wantErr: true},
 	}
@@ -395,7 +409,11 @@ func TestGitHubClaimIssue(t *testing.T) {
 				require.Len(t, assignees, 1)
 				assert.Equal(t, "bot-user", assignees[0])
 
-				respondGitHubJSON(w, tt.statusCode, map[string]interface{}{"ok": true})
+				respBody := tt.respBody
+				if respBody == nil {
+					respBody = map[string]interface{}{"ok": true}
+				}
+				respondGitHubJSON(w, tt.statusCode, respBody)
 			}))
 			defer server.Close()
 

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -754,16 +754,25 @@ func getTime(m map[string]interface{}, key string) time.Time {
 	return t
 }
 
-// parseRetryAfter parses the Retry-After header value as seconds.
+// parseRetryAfter parses the Retry-After header value. RFC 9110 allows both
+// delta-seconds and an HTTP-date; treating a date as "no delay" would hammer
+// a rate-limited API in a tight retry loop.
 func parseRetryAfter(val string) time.Duration {
 	if val == "" {
 		return 0
 	}
-	seconds, err := strconv.Atoi(val)
-	if err != nil {
-		return 0
+	if seconds, err := strconv.Atoi(val); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
 	}
-	return time.Duration(seconds) * time.Second
+	if at, err := http.ParseTime(val); err == nil {
+		if delay := time.Until(at); delay > 0 {
+			return delay
+		}
+	}
+	return 0
 }
 
 // truncateBody truncates a response body for error messages.

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -109,6 +109,7 @@ const fetchIssuesQuery = `query FetchIssues($projectSlug: String!, $first: Int!,
 			description
 			priority
 			state { name type }
+			assignee { id }
 			url
 			labels { nodes { name } }
 			createdAt
@@ -218,6 +219,9 @@ func (c *LinearClient) FetchIssues(ctx context.Context) ([]types.Issue, error) {
 		for _, iss := range issues {
 			stateType, _ := iss.TrackerMeta["linear_state_type"].(string)
 			if !isClaimableLinearStateType(stateType) {
+				continue
+			}
+			if !c.isDispatchSafeAssignee(iss) {
 				continue
 			}
 			allIssues = append(allIssues, iss)
@@ -528,6 +532,11 @@ func normalizeIssue(node map[string]interface{}) types.Issue {
 		linearStateType, _ = state["type"].(string)
 	}
 
+	assigneeID := ""
+	if assignee, ok := node["assignee"].(map[string]interface{}); ok {
+		assigneeID, _ = assignee["id"].(string)
+	}
+
 	identifier := getString(node, "identifier")
 	priority := getInt(node, "priority")
 	createdAt := getTime(node, "createdAt")
@@ -553,10 +562,26 @@ func normalizeIssue(node map[string]interface{}) types.Issue {
 		CreatedAt:     createdAt,
 		UpdatedAt:     updatedAt,
 		TrackerMeta: map[string]interface{}{
-			"linear_state":      linearState,
-			"linear_state_type": linearStateType,
+			"linear_state":       linearState,
+			"linear_state_type":  linearStateType,
+			"linear_assignee_id": assigneeID,
 		},
 	}
+}
+
+// isDispatchSafeAssignee reports whether an issue's assignee allows the
+// orchestrator to manage it. Issues assigned to a different Linear user are
+// excluded entirely: returning them would let orphan-claim recovery re-assign
+// a teammate's In Progress issue to the bot and start an agent on it.
+// Unassigned issues and issues already assigned to the configured assignee
+// stay manageable. When no assignee ID is configured, ownership cannot be
+// established and nothing is filtered.
+func (c *LinearClient) isDispatchSafeAssignee(issue types.Issue) bool {
+	if c.assigneeID == "" {
+		return true
+	}
+	assigneeID, _ := issue.TrackerMeta["linear_assignee_id"].(string)
+	return assigneeID == "" || assigneeID == c.assigneeID
 }
 
 // terminalLinearStateTypes lists Linear state.type values for issues that the
@@ -564,13 +589,15 @@ func normalizeIssue(node map[string]interface{}) types.Issue {
 // was just successfully released (state=Done, type=completed) would reappear in
 // the next poll as Unclaimed and be picked up again, producing a re-claim loop.
 //
-// "completed" and "canceled" cover Linear's terminal types. "backlog" is also
-// excluded so triage-stage issues don't get picked up before a human moves them
-// to Todo / In Progress.
+// "completed" and "canceled" cover Linear's terminal types. "backlog" and
+// "triage" are also excluded so pre-planning issues don't get picked up before
+// a human moves them to Todo / In Progress. (Linear's state types are: triage,
+// backlog, unstarted, started, completed, canceled.)
 var terminalLinearStateTypes = map[string]struct{}{
 	"completed": {},
 	"canceled":  {},
 	"backlog":   {},
+	"triage":    {},
 }
 
 // isClaimableLinearStateType reports whether an issue with this Linear state

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -1088,9 +1088,9 @@ func TestParseRetryAfter_NonNumeric(t *testing.T) {
 		{"empty string", "", 0},
 		{"non-numeric text", "not-a-number", 0},
 		{"float value", "3.14", 0},
-		{"negative number", "-5", -5 * time.Second},
+		{"negative number clamps to zero", "-5", 0},
 		{"valid seconds", "60", 60 * time.Second},
-		{"HTTP date format", "Wed, 21 Oct 2025 07:28:00 GMT", 0},
+		{"HTTP date in the past", "Wed, 21 Oct 2015 07:28:00 GMT", 0},
 	}
 
 	for _, tt := range tests {
@@ -1099,6 +1099,15 @@ func TestParseRetryAfter_NonNumeric(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+
+	// RFC 9110 also allows an HTTP-date; a future date must yield a positive
+	// delay instead of 0 (which would hammer a rate-limited API).
+	t.Run("HTTP date in the future", func(t *testing.T) {
+		future := time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)
+		got := parseRetryAfter(future)
+		assert.Greater(t, got, 60*time.Second)
+		assert.LessOrEqual(t, got, 90*time.Second)
+	})
 }
 
 // --- FetchIssues Missing Data Field Test ---

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -114,6 +114,145 @@ func TestFetchIssues_ParsesResponse(t *testing.T) {
 	assert.Equal(t, "Backlog", issues[1].TrackerMeta["linear_state"])
 }
 
+// TestFetchIssues_FiltersIssuesAssignedToOthers exercises the claim-safety
+// guard: an issue assigned to a different Linear user must never reach the
+// orchestrator. Before this filter, a teammate's In Progress issue mapped to
+// Claimed, was "recovered" as orphaned (no local agent runs it), re-assigned
+// to the bot, and an agent started working on it.
+func TestFetchIssues_FiltersIssuesAssignedToOthers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := parseGQLRequest(t, r)
+		assert.Contains(t, req.Query, "assignee { id }")
+
+		respondJSON(w, 200, map[string]interface{}{
+			"data": map[string]interface{}{
+				"issues": map[string]interface{}{
+					"nodes": []interface{}{
+						map[string]interface{}{
+							"id":     "unassigned-todo",
+							"title":  "Unassigned Todo",
+							"state":  map[string]interface{}{"name": "Todo", "type": "unstarted"},
+							"labels": map[string]interface{}{"nodes": []interface{}{}},
+						},
+						map[string]interface{}{
+							"id":       "own-in-progress",
+							"title":    "Bot's own in-flight issue",
+							"state":    map[string]interface{}{"name": "In Progress", "type": "started"},
+							"assignee": map[string]interface{}{"id": "user-123"},
+							"labels":   map[string]interface{}{"nodes": []interface{}{}},
+						},
+						map[string]interface{}{
+							"id":       "teammate-in-progress",
+							"title":    "Teammate's in-flight issue",
+							"state":    map[string]interface{}{"name": "In Progress", "type": "started"},
+							"assignee": map[string]interface{}{"id": "human-456"},
+							"labels":   map[string]interface{}{"nodes": []interface{}{}},
+						},
+						map[string]interface{}{
+							"id":       "teammate-todo",
+							"title":    "Todo already assigned to a teammate",
+							"state":    map[string]interface{}{"name": "Todo", "type": "unstarted"},
+							"assignee": map[string]interface{}{"id": "human-456"},
+							"labels":   map[string]interface{}{"nodes": []interface{}{}},
+						},
+					},
+					"pageInfo": map[string]interface{}{"hasNextPage": false},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(t, server.URL) // configured with AssigneeID "user-123"
+	issues, err := client.FetchIssues(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+
+	assert.Equal(t, "unassigned-todo", issues[0].ID)
+	assert.Equal(t, types.Unclaimed, issues[0].State)
+	assert.Equal(t, "", issues[0].TrackerMeta["linear_assignee_id"])
+
+	// The bot's own claim survives a restart as Claimed so orphan recovery,
+	// not fresh dispatch, decides what happens to it.
+	assert.Equal(t, "own-in-progress", issues[1].ID)
+	assert.Equal(t, types.Claimed, issues[1].State)
+	assert.Equal(t, "user-123", issues[1].TrackerMeta["linear_assignee_id"])
+}
+
+// TestFetchIssues_NoAssigneeConfiguredSkipsFilter pins the fallback: without a
+// configured assignee ID, ownership cannot be established, so assigned issues
+// are not filtered (pre-filter behavior).
+func TestFetchIssues_NoAssigneeConfiguredSkipsFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, 200, map[string]interface{}{
+			"data": map[string]interface{}{
+				"issues": map[string]interface{}{
+					"nodes": []interface{}{
+						map[string]interface{}{
+							"id":       "assigned-elsewhere",
+							"title":    "Assigned to someone",
+							"state":    map[string]interface{}{"name": "Todo", "type": "unstarted"},
+							"assignee": map[string]interface{}{"id": "human-456"},
+							"labels":   map[string]interface{}{"nodes": []interface{}{}},
+						},
+					},
+					"pageInfo": map[string]interface{}{"hasNextPage": false},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewLinearClient(LinearConfig{
+		APIKey:      "test-api-key",
+		ProjectSlug: "test-project",
+		Endpoint:    server.URL,
+	})
+	require.NoError(t, err)
+
+	issues, err := client.FetchIssues(context.Background())
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "assigned-elsewhere", issues[0].ID)
+}
+
+// TestFetchIssues_FiltersTriageState pins the triage exclusion: issues still
+// in Linear's Triage inbox must not be dispatched before a human accepts them.
+func TestFetchIssues_FiltersTriageState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, 200, map[string]interface{}{
+			"data": map[string]interface{}{
+				"issues": map[string]interface{}{
+					"nodes": []interface{}{
+						map[string]interface{}{
+							"id":     "triage-issue",
+							"title":  "Untriaged report",
+							"state":  map[string]interface{}{"name": "Triage", "type": "triage"},
+							"labels": map[string]interface{}{"nodes": []interface{}{}},
+						},
+						map[string]interface{}{
+							"id":     "todo-issue",
+							"title":  "Accepted Todo",
+							"state":  map[string]interface{}{"name": "Todo", "type": "unstarted"},
+							"labels": map[string]interface{}{"nodes": []interface{}{}},
+						},
+					},
+					"pageInfo": map[string]interface{}{"hasNextPage": false},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(t, server.URL)
+	issues, err := client.FetchIssues(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "todo-issue", issues[0].ID)
+}
+
 func TestFetchIssues_EmptyResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, 200, map[string]interface{}{

--- a/internal/tracker/local.go
+++ b/internal/tracker/local.go
@@ -122,6 +122,19 @@ func (t *LocalTracker) BoardDir() string {
 	return t.boardDir
 }
 
+// lockBoardFile takes the cross-process board lock. The daemon and the
+// `contrabass board`/`team` CLIs open the same BoardDir from separate
+// processes; t.mu only serializes within one process. Callers must already
+// hold t.mu (so lock ordering is always mu → file lock) and must call the
+// returned release func.
+func (t *LocalTracker) lockBoardFile() (func(), error) {
+	lock := newFileLock(filepath.Join(t.boardDir, "board"))
+	if err := lock.Lock(); err != nil {
+		return nil, fmt.Errorf("lock board: %w", err)
+	}
+	return func() { _ = lock.Unlock() }, nil
+}
+
 func ParseLocalBoardState(raw string) (LocalBoardState, error) {
 	switch LocalBoardState(strings.TrimSpace(raw)) {
 	case LocalBoardStateTodo:
@@ -189,6 +202,12 @@ func (t *LocalTracker) ClaimIssue(ctx context.Context, issueID string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return err
 	}
@@ -215,6 +234,12 @@ func (t *LocalTracker) ReleaseIssue(ctx context.Context, issueID string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return err
 	}
@@ -237,6 +262,12 @@ func (t *LocalTracker) UpdateIssueState(ctx context.Context, issueID string, sta
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return err
@@ -268,6 +299,12 @@ func (t *LocalTracker) PostComment(ctx context.Context, issueID string, body str
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return err
@@ -304,6 +341,12 @@ func (t *LocalTracker) CreateIssueWithOptions(ctx context.Context, opts LocalIss
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return LocalBoardIssue{}, err
+	}
+	defer release()
 
 	manifest, err := t.ensureBoardLocked()
 	if err != nil {
@@ -533,6 +576,12 @@ func (t *LocalTracker) UpdateIssue(
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return LocalBoardIssue{}, err
+	}
+	defer release()
+
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return LocalBoardIssue{}, err
 	}
@@ -561,6 +610,12 @@ func (t *LocalTracker) MoveIssue(ctx context.Context, issueID string, state Loca
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return LocalBoardIssue{}, err
+	}
+	defer release()
 
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return LocalBoardIssue{}, err
@@ -805,15 +860,36 @@ func writeJSONAtomic(path string, value interface{}) error {
 		return fmt.Errorf("encoding %s: %w", path, err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating parent directory for %s: %w", path, err)
 	}
 
-	tempPath := path + ".tmp"
-	if err := os.WriteFile(tempPath, append(data, '\n'), 0o644); err != nil {
+	// A unique temp name per writer: with a fixed "<path>.tmp" two concurrent
+	// writers (daemon + CLI) truncate each other's temp file and one renames
+	// a half-written or foreign payload into place.
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file for %s: %w", path, err)
+	}
+	tempPath := tmp.Name()
+
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tempPath)
 		return fmt.Errorf("writing temp file for %s: %w", path, err)
 	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("closing temp file for %s: %w", path, err)
+	}
+	// CreateTemp uses 0600; keep board files group/world-readable as before.
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("chmod temp file for %s: %w", path, err)
+	}
 	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
 		return fmt.Errorf("renaming temp file for %s: %w", path, err)
 	}
 

--- a/internal/tracker/local.go
+++ b/internal/tracker/local.go
@@ -30,6 +30,12 @@ const (
 var localBoardPrefixPattern = regexp.MustCompile(`[^A-Za-z0-9]+`)
 var localBoardTeamPattern = regexp.MustCompile(`[^a-z0-9]+`)
 
+// localIssueIDPattern restricts issue IDs to filename-safe characters.
+// Issue IDs arrive from the CLI and the web API and are joined into
+// filesystem paths (issues/<id>.json, comments/<id>.jsonl); this prevents
+// path traversal via "../" or other metacharacters.
+var localIssueIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
 type LocalConfig struct {
 	BoardDir    string
 	IssuePrefix string
@@ -734,6 +740,10 @@ func (t *LocalTracker) ensureBoardLocked() (*LocalBoardManifest, error) {
 }
 
 func (t *LocalTracker) loadIssueLocked(issueID string) (LocalBoardIssue, error) {
+	if !localIssueIDPattern.MatchString(issueID) {
+		return LocalBoardIssue{}, fmt.Errorf("local board issue id %q contains invalid characters", issueID)
+	}
+
 	var issue LocalBoardIssue
 	if err := readJSONFile(t.issuePath(issueID), &issue); err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/tracker/local.go
+++ b/internal/tracker/local.go
@@ -95,10 +95,11 @@ type LocalIssueCreateOptions struct {
 }
 
 type LocalTracker struct {
-	boardDir    string
-	issuePrefix string
-	actor       string
-	mu          sync.Mutex
+	boardDir         string
+	issuePrefix      string
+	actor            string
+	mu               sync.Mutex
+	activeClaimLocks map[string]*fileLock
 }
 
 var _ Tracker = (*LocalTracker)(nil)
@@ -118,9 +119,10 @@ func NewLocalTracker(cfg LocalConfig) *LocalTracker {
 	}
 
 	return &LocalTracker{
-		boardDir:    filepath.Clean(boardDir),
-		issuePrefix: sanitizeLocalIssuePrefix(cfg.IssuePrefix),
-		actor:       actor,
+		boardDir:         filepath.Clean(boardDir),
+		issuePrefix:      sanitizeLocalIssuePrefix(cfg.IssuePrefix),
+		actor:            actor,
+		activeClaimLocks: make(map[string]*fileLock),
 	}
 }
 
@@ -139,6 +141,34 @@ func (t *LocalTracker) lockBoardFile() (func(), error) {
 		return nil, fmt.Errorf("lock board: %w", err)
 	}
 	return func() { _ = lock.Unlock() }, nil
+}
+
+// tryLockIssueClaim takes a process-lifetime lock for one actively claimed
+// issue. Unlike the board mutation lock, this lock remains held while the
+// agent runs, so another daemon cannot mistake the live claim for an orphan.
+// flock is released by the OS if the claiming process crashes.
+func (t *LocalTracker) tryLockIssueClaim(issueID string) (*fileLock, error) {
+	lock := newFileLock(filepath.Join(t.boardDir, "claims", issueID))
+	acquired, err := lock.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("lock claim for issue %s: %w", issueID, err)
+	}
+	if !acquired {
+		return nil, fmt.Errorf("local board issue %q is already claimed by another process", issueID)
+	}
+	return lock, nil
+}
+
+func (t *LocalTracker) releaseIssueClaimLocked(issueID string) error {
+	lock, ok := t.activeClaimLocks[issueID]
+	if !ok {
+		return nil
+	}
+	delete(t.activeClaimLocks, issueID)
+	if err := lock.Unlock(); err != nil {
+		return fmt.Errorf("unlock claim for issue %s: %w", issueID, err)
+	}
+	return nil
 }
 
 func ParseLocalBoardState(raw string) (LocalBoardState, error) {
@@ -183,6 +213,12 @@ func (t *LocalTracker) InitBoard(ctx context.Context) (*LocalBoardManifest, erro
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	release, err := t.lockBoardFile()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	return t.ensureBoardLocked()
 }
 
@@ -204,6 +240,9 @@ func (t *LocalTracker) ClaimIssue(ctx context.Context, issueID string) error {
 	if err := checkLocalTrackerContext(ctx); err != nil {
 		return err
 	}
+	if !localIssueIDPattern.MatchString(issueID) {
+		return fmt.Errorf("local board issue id %q contains invalid characters", issueID)
+	}
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -217,19 +256,39 @@ func (t *LocalTracker) ClaimIssue(ctx context.Context, issueID string) error {
 	if _, err := t.ensureBoardLocked(); err != nil {
 		return err
 	}
+	if _, claimed := t.activeClaimLocks[issueID]; claimed {
+		return fmt.Errorf("local board issue %q is already claimed by this process", issueID)
+	}
+
+	claimLock, err := t.tryLockIssueClaim(issueID)
+	if err != nil {
+		return err
+	}
+	releaseClaimLock := true
+	defer func() {
+		if releaseClaimLock {
+			_ = claimLock.Unlock()
+		}
+	}()
 
 	issue, err := t.loadIssueLocked(issueID)
 	if err != nil {
 		return err
 	}
-
-	if issue.State != LocalBoardStateDone {
-		issue.State = LocalBoardStateInProgress
+	if issue.State == LocalBoardStateDone {
+		return fmt.Errorf("local board issue %q is already done", issueID)
 	}
+
+	issue.State = LocalBoardStateInProgress
 	issue.ClaimedBy = t.actor
 	issue.UpdatedAt = time.Now().UTC()
 
-	return writeJSONAtomic(t.issuePath(issueID), issue)
+	if err := writeJSONAtomic(t.issuePath(issueID), issue); err != nil {
+		return err
+	}
+	t.activeClaimLocks[issueID] = claimLock
+	releaseClaimLock = false
+	return nil
 }
 
 func (t *LocalTracker) ReleaseIssue(ctx context.Context, issueID string) error {
@@ -258,7 +317,10 @@ func (t *LocalTracker) ReleaseIssue(ctx context.Context, issueID string) error {
 	issue.ClaimedBy = ""
 	issue.UpdatedAt = time.Now().UTC()
 
-	return writeJSONAtomic(t.issuePath(issueID), issue)
+	if err := writeJSONAtomic(t.issuePath(issueID), issue); err != nil {
+		return err
+	}
+	return t.releaseIssueClaimLocked(issueID)
 }
 
 func (t *LocalTracker) UpdateIssueState(ctx context.Context, issueID string, state types.IssueState) error {
@@ -295,7 +357,13 @@ func (t *LocalTracker) UpdateIssueState(ctx context.Context, issueID string, sta
 	}
 	issue.UpdatedAt = time.Now().UTC()
 
-	return writeJSONAtomic(t.issuePath(issueID), issue)
+	if err := writeJSONAtomic(t.issuePath(issueID), issue); err != nil {
+		return err
+	}
+	if issue.State != LocalBoardStateInProgress {
+		return t.releaseIssueClaimLocked(issueID)
+	}
+	return nil
 }
 
 func (t *LocalTracker) PostComment(ctx context.Context, issueID string, body string) error {

--- a/internal/tracker/local.go
+++ b/internal/tracker/local.go
@@ -137,10 +137,16 @@ func ParseLocalBoardState(raw string) (LocalBoardState, error) {
 	}
 }
 
+// IssueState maps a board state to the orchestrator's claim state.
+// in_progress maps to Claimed (not Running) so that a crashed run — which
+// leaves the issue in_progress with no live agent — is picked up by
+// orphan-claim recovery instead of being stranded forever. This mirrors the
+// Linear adapter's started→Claimed mapping; the orchestrator itself decides
+// what is actively Running from its in-memory managed set.
 func (s LocalBoardState) IssueState() types.IssueState {
 	switch s {
 	case LocalBoardStateInProgress:
-		return types.Running
+		return types.Claimed
 	case LocalBoardStateRetry:
 		return types.RetryQueued
 	case LocalBoardStateDone:

--- a/internal/tracker/local_test.go
+++ b/internal/tracker/local_test.go
@@ -112,6 +112,36 @@ func TestLocalTrackerLifecycle(t *testing.T) {
 	assert.Equal(t, LocalBoardStateDone, allIssues[0].State)
 }
 
+// TestLocalBoardInProgressMapsToClaimed pins the crash-recovery contract: an
+// in_progress issue left behind by a crashed run must surface as Claimed so
+// the orchestrator's orphan-claim recovery (which only looks at Claimed)
+// re-dispatches it. Mapping it to Running strands the issue forever.
+func TestLocalBoardInProgressMapsToClaimed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	localTracker := NewLocalTracker(LocalConfig{
+		BoardDir: filepath.Join(t.TempDir(), "board"),
+		Actor:    "bot",
+	})
+
+	issue, err := localTracker.CreateIssue(ctx, "Crashes mid-run", "", nil)
+	require.NoError(t, err)
+	require.NoError(t, localTracker.ClaimIssue(ctx, issue.ID))
+
+	// Simulate an orchestrator restart: nothing is in the managed set, and
+	// FetchIssues reports the board as-is.
+	fetched, err := localTracker.FetchIssues(ctx)
+	require.NoError(t, err)
+	require.Len(t, fetched, 1)
+	assert.Equal(t, types.Claimed, fetched[0].State)
+
+	assert.Equal(t, types.Claimed, LocalBoardStateInProgress.IssueState())
+	assert.Equal(t, types.RetryQueued, LocalBoardStateRetry.IssueState())
+	assert.Equal(t, types.Released, LocalBoardStateDone.IssueState())
+	assert.Equal(t, types.Unclaimed, LocalBoardStateTodo.IssueState())
+}
+
 func TestLocalTrackerUpdateIssue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/local_test.go
+++ b/internal/tracker/local_test.go
@@ -164,6 +164,34 @@ func TestLocalTrackerConcurrentInstancesMintUniqueIDs(t *testing.T) {
 	}
 }
 
+func TestLocalTrackerClaimIsExclusiveAcrossInstances(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	boardDir := filepath.Join(t.TempDir(), "board")
+	trackerA := NewLocalTracker(LocalConfig{BoardDir: boardDir, Actor: "daemon"})
+	trackerB := NewLocalTracker(LocalConfig{BoardDir: boardDir, Actor: "cli"})
+
+	issue, err := trackerA.CreateIssue(ctx, "exclusive claim", "", nil)
+	require.NoError(t, err)
+	require.NoError(t, trackerA.ClaimIssue(ctx, issue.ID))
+
+	err = trackerB.ClaimIssue(ctx, issue.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already claimed by another process")
+
+	current, err := trackerA.GetIssue(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "daemon", current.ClaimedBy)
+
+	// Terminal state releases the process-lifetime claim lock. A later caller
+	// must still reject the completed issue rather than launch duplicate work.
+	require.NoError(t, trackerA.UpdateIssueState(ctx, issue.ID, types.Released))
+	err = trackerB.ClaimIssue(ctx, issue.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already done")
+}
+
 // TestLocalBoardInProgressMapsToClaimed pins the crash-recovery contract: an
 // in_progress issue left behind by a crashed run must surface as Claimed so
 // the orchestrator's orphan-claim recovery (which only looks at Claimed)

--- a/internal/tracker/local_test.go
+++ b/internal/tracker/local_test.go
@@ -2,7 +2,9 @@ package tracker
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,6 +112,56 @@ func TestLocalTrackerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allIssues, 1)
 	assert.Equal(t, LocalBoardStateDone, allIssues[0].State)
+}
+
+// TestLocalTrackerConcurrentInstancesMintUniqueIDs pins the cross-process
+// locking contract. The daemon and the `contrabass board`/`team` CLIs open
+// the same BoardDir from separate processes; each LocalTracker instance has
+// its own sync.Mutex, so only the flock serializes the manifest
+// read-modify-write. Two instances in one test simulate two processes (flock
+// contends across separate file descriptors even within a process). Without
+// the lock this races: duplicate issue IDs are minted and issue files are
+// silently overwritten.
+func TestLocalTrackerConcurrentInstancesMintUniqueIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	boardDir := filepath.Join(t.TempDir(), "board")
+
+	trackerA := NewLocalTracker(LocalConfig{BoardDir: boardDir, Actor: "daemon"})
+	trackerB := NewLocalTracker(LocalConfig{BoardDir: boardDir, Actor: "cli"})
+
+	const perTracker = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2*perTracker)
+
+	for _, tr := range []*LocalTracker{trackerA, trackerB} {
+		for i := 0; i < perTracker; i++ {
+			wg.Add(1)
+			go func(tr *LocalTracker, i int) {
+				defer wg.Done()
+				if _, err := tr.CreateIssue(ctx, fmt.Sprintf("issue %d", i), "", nil); err != nil {
+					errCh <- err
+				}
+			}(tr, i)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	issues, err := trackerA.ListIssues(ctx, true)
+	require.NoError(t, err)
+	require.Len(t, issues, 2*perTracker, "every CreateIssue must land as its own file")
+
+	seen := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		_, dup := seen[issue.ID]
+		require.Falsef(t, dup, "duplicate issue ID minted: %s", issue.ID)
+		seen[issue.ID] = struct{}{}
+	}
 }
 
 // TestLocalBoardInProgressMapsToClaimed pins the crash-recovery contract: an


### PR DESCRIPTION
Part 1/3 of the full-codebase audit fix plan (`.omc/plans/2026-07-16-contrabass-audit-fix-plan.md`). All findings were verified at line level before fixing; every fix ships with a regression test.

## P0 — claim-safety cluster

The orchestrator's orphan recovery flips any `Claimed` issue absent from its in-memory managed set to `Unclaimed` and re-dispatches it. All three adapters fed it wrong data:

- **Linear**: `FetchIssues` selected no assignee → a teammate's In Progress issue was "recovered", re-assigned to the bot, and an agent started working on it. The query now selects `assignee { id }` and issues assigned to another user never reach the orchestrator.
- **GitHub**: assignees were never decoded and `State` was hardcoded `Unclaimed` → human-assigned issues got dispatched (`POST /assignees` is additive, so claiming silently "succeeds"), and after a restart the bot's own in-flight issues re-ran from attempt 1. Now: assigned-to-other → excluded; assigned-to-bot → `Claimed` (mirrors Linear's `started`→`Claimed`).
- **Local board**: `in_progress` mapped to `Running`, which orphan recovery ignores → crashed issues stranded forever. Now maps to `Claimed`.
- **Linear**: `triage` added to the non-claimable state types.

## P1 — cross-process board safety

- Board mutations now take an exclusive `flock(2)` (`<BoardDir>/board.lock`): the daemon and `contrabass board`/`team` CLIs share one BoardDir from separate processes, and the manifest read-modify-write could mint duplicate issue IDs.
- `writeJSONAtomic` uses `os.CreateTemp` per writer instead of a fixed `<path>.tmp` that concurrent writers truncated.

## P2 — hardening

- GitHub `ClaimIssue` verifies the assignee actually landed (201 is returned even when GitHub silently ignores an unassignable login).
- `parseRetryAfter` handles RFC 9110 HTTP-dates and clamps negatives.
- Local issue IDs validated before being joined into filesystem paths.

## Tests

`go test ./internal/tracker/ ./internal/orchestrator/ ./tests/e2e/ -race` green. New: `TestFetchIssues_FiltersIssuesAssignedToOthers`, `TestFetchIssues_NoAssigneeConfiguredSkipsFilter`, `TestFetchIssues_FiltersTriageState`, `TestGitHubFetchIssues_AssigneeClaimSafety`, `TestLocalBoardInProgressMapsToClaimed`, `TestLocalTrackerConcurrentInstancesMintUniqueIDs`, expanded `TestGitHubClaimIssue` + `TestParseRetryAfter`.