### PR TITLE
fix(workspace): preserve issue-branch commits; clean plain-dir workspaces

### DIFF
--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -23,16 +23,23 @@ type Manager struct {
 	baseDir   string
 	gitBinary string
 
-	mu         sync.RWMutex
-	active     map[string]string
-	issueLocks sync.Map
+	mu           sync.RWMutex
+	active       map[string]string
+	issueLocksMu sync.Mutex
+	issueLocks   map[string]*issueLockEntry
+}
+
+type issueLockEntry struct {
+	mu   sync.Mutex
+	refs int
 }
 
 func NewManager(baseDir string) *Manager {
 	return &Manager{
-		baseDir:   baseDir,
-		gitBinary: "git",
-		active:    make(map[string]string),
+		baseDir:    baseDir,
+		gitBinary:  "git",
+		active:     make(map[string]string),
+		issueLocks: make(map[string]*issueLockEntry),
 	}
 }
 
@@ -46,6 +53,9 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	unlock := m.lockIssue(issue.ID)
 	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
 	workspacePath := m.workspacePath(issue.ID)
 
@@ -54,8 +64,17 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 	m.mu.RUnlock()
 	if tracked {
 		if info, err := os.Stat(trackedPath); err == nil && info.IsDir() {
-			return trackedPath, nil
+			registered, err := m.isRegisteredWorktree(ctx, trackedPath)
+			if err != nil {
+				return "", fmt.Errorf("verify tracked workspace for issue %s: %w", issue.ID, err)
+			}
+			if registered {
+				return trackedPath, nil
+			}
 		}
+		m.mu.Lock()
+		delete(m.active, issue.ID)
+		m.mu.Unlock()
 	}
 
 	// If the path already exists, only reuse it when it is a registered git
@@ -65,7 +84,11 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 	// looks like the parent repo's working tree and fails the
 	// `leader_workspace_dirty` check.
 	if info, err := os.Stat(workspacePath); err == nil && info.IsDir() {
-		if m.isRegisteredWorktree(ctx, workspacePath) {
+		registered, err := m.isRegisteredWorktree(ctx, workspacePath)
+		if err != nil {
+			return "", fmt.Errorf("verify existing workspace for issue %s: %w", issue.ID, err)
+		}
+		if registered {
 			m.mu.Lock()
 			m.active[issue.ID] = workspacePath
 			m.mu.Unlock()
@@ -78,11 +101,6 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	if err := os.MkdirAll(filepath.Dir(workspacePath), 0o755); err != nil {
 		return "", fmt.Errorf("create workspace parent directory: %w", err)
-	}
-
-	// Verify context is still valid before any I/O.
-	if err := ctx.Err(); err != nil {
-		return "", err
 	}
 
 	// If the base directory is not a git repo, create a plain directory
@@ -119,6 +137,13 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 		// (rm -rf without `worktree remove`) blocks every `worktree add` at
 		// this path until pruned. Prune stale registrations once and retry
 		// before giving up — otherwise the issue is permanently undispatchable.
+		prunable, lookupErr := m.hasPrunableWorktreeRegistration(ctx, workspacePath)
+		if lookupErr != nil {
+			return "", fmt.Errorf("inspect stale worktree registration for issue %s: %w", issue.ID, lookupErr)
+		}
+		if !prunable {
+			return "", fmt.Errorf("create git worktree for issue %s on branch %s: %w", issue.ID, branchName, err)
+		}
 		if _, pruneErr := m.runGit(ctx, "worktree", "prune"); pruneErr != nil {
 			return "", fmt.Errorf(
 				"create git worktree for issue %s on branch %s: %w (git worktree prune also failed: %v)",
@@ -134,7 +159,11 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 	}
 
 	// Verify the worktree actually registered before declaring success.
-	if !m.isRegisteredWorktree(ctx, workspacePath) {
+	registered, err := m.isRegisteredWorktree(ctx, workspacePath)
+	if err != nil {
+		return "", fmt.Errorf("verify created workspace for issue %s: %w", issue.ID, err)
+	}
+	if !registered {
 		return "", fmt.Errorf(
 			"git worktree add for issue %s reported success but path %s is not a registered worktree",
 			issue.ID, workspacePath,
@@ -267,19 +296,36 @@ func (m *Manager) workspacePath(issueID string) string {
 	return filepath.Join(m.baseDir, "workspaces", issueID)
 }
 
-// lockIssue serializes Create/Cleanup per issue ID. Lock entries are never
-// deleted: removing one from Cleanup races a concurrent lockIssue that
-// already loaded the entry, letting two goroutines hold "the" lock for the
-// same issue at once. The map is bounded by the number of distinct issue IDs
-// seen in the process lifetime, which is small.
+// lockIssue serializes Create/Cleanup per issue ID. References include both
+// holders and waiters, so an entry is only reclaimed after the final caller
+// releases it; this avoids the old delete/load race without retaining one
+// mutex for every issue ever seen.
 func (m *Manager) lockIssue(issueID string) func() {
-	issueLock, _ := m.issueLocks.LoadOrStore(issueID, &sync.Mutex{})
-	mu := issueLock.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	m.issueLocksMu.Lock()
+	entry := m.issueLocks[issueID]
+	if entry == nil {
+		entry = &issueLockEntry{}
+		m.issueLocks[issueID] = entry
+	}
+	entry.refs++
+	m.issueLocksMu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+		m.issueLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 && m.issueLocks[issueID] == entry {
+			delete(m.issueLocks, issueID)
+		}
+		m.issueLocksMu.Unlock()
+	}
 }
 
-// isRegisteredWorktree returns true when path appears in `git worktree list`.
+// isRegisteredWorktree reports whether path is a non-prunable registered
+// worktree with Git's linked-worktree metadata in place. Lookup failures are
+// returned so Create never deletes a potentially valid workspace on uncertain
+// Git state.
 // Used to distinguish real worktrees from bare directories left by crashed
 // runs so Create knows which paths are safe to reuse vs. tear down.
 //
@@ -287,28 +333,74 @@ func (m *Manager) lockIssue(issueID string) func() {
 // path Go reports via `filepath.Abs` may differ from what git prints in
 // `worktree list --porcelain`. Symlink-resolve both sides before comparing
 // so test temp dirs and production paths match correctly.
-func (m *Manager) isRegisteredWorktree(ctx context.Context, path string) bool {
-	output, err := m.runGit(ctx, "worktree", "list", "--porcelain")
+func (m *Manager) isRegisteredWorktree(ctx context.Context, path string) (bool, error) {
+	registered, prunable, err := m.worktreeRegistration(ctx, path)
 	if err != nil {
-		return false
+		return false, err
 	}
-	abs := resolvedAbs(path)
-	for _, line := range strings.Split(output, "\n") {
-		rest, ok := strings.CutPrefix(line, "worktree ")
-		if !ok {
-			continue
-		}
-		entry := resolvedAbs(strings.TrimSpace(rest))
-		if entry == abs {
-			return true
-		}
+	if !registered || prunable {
+		return false, nil
 	}
-	return false
+
+	gitFile, err := os.ReadFile(filepath.Join(path, ".git"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read worktree metadata: %w", err)
+	}
+	return strings.HasPrefix(strings.TrimSpace(string(gitFile)), "gitdir: "), nil
 }
 
-// resolvedAbs returns the absolute, symlink-resolved form of path. Falls back
-// to the un-resolved absolute path (or the input verbatim) on any error so
-// callers always get a usable string.
+func (m *Manager) hasPrunableWorktreeRegistration(ctx context.Context, path string) (bool, error) {
+	registered, prunable, err := m.worktreeRegistration(ctx, path)
+	if err != nil || !registered {
+		return false, err
+	}
+	if prunable {
+		return true, nil
+	}
+	// Older Git versions do not always print a porcelain `prunable` line for
+	// a removed linked worktree, even though `worktree add` rejects the stale
+	// registration. The absent directory is equally definitive here.
+	_, statErr := os.Stat(path)
+	return errors.Is(statErr, os.ErrNotExist), nil
+}
+
+func (m *Manager) worktreeRegistration(ctx context.Context, path string) (bool, bool, error) {
+	output, err := m.runGit(ctx, "worktree", "list", "--porcelain")
+	if err != nil {
+		return false, false, err
+	}
+	target := resolvedAbs(path)
+	currentPath := ""
+	currentPrunable := false
+	matchCurrent := func() (bool, bool) {
+		return currentPath != "" && resolvedAbs(currentPath) == target, currentPrunable
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if rest, ok := strings.CutPrefix(line, "worktree "); ok {
+			if registered, prunable := matchCurrent(); registered {
+				return true, prunable, nil
+			}
+			currentPath = strings.TrimSpace(rest)
+			currentPrunable = false
+			continue
+		}
+		if strings.HasPrefix(line, "prunable") {
+			currentPrunable = true
+		}
+	}
+	registered, prunable := matchCurrent()
+	return registered, prunable, nil
+}
+
+// resolvedAbs returns the absolute, symlink-resolved form of path. When the
+// final path does not exist (as with a stale worktree), it resolves the
+// longest existing parent and appends the absent suffix. That preserves the
+// canonical /private/var form Git emits on macOS for a missing /var path.
+// Falls back to the un-resolved absolute path (or the input verbatim) on any
+// error so callers always get a usable string.
 func resolvedAbs(path string) string {
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -316,6 +408,18 @@ func resolvedAbs(path string) string {
 	}
 	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
 		return resolved
+	}
+
+	var suffix []string
+	for parent := abs; ; parent = filepath.Dir(parent) {
+		if resolved, err := filepath.EvalSymlinks(parent); err == nil {
+			return filepath.Join(append([]string{resolved}, suffix...)...)
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			break
+		}
+		suffix = append([]string{filepath.Base(parent)}, suffix...)
 	}
 	return abs
 }
@@ -326,8 +430,7 @@ func resolvedAbs(path string) string {
 // transient error inside a real repo from downgrading the workspace to a
 // plain directory.
 func (m *Manager) isOutsideGitRepo(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx, m.gitBinary, "rev-parse", "--git-dir")
-	cmd.Dir = m.baseDir
+	cmd := m.gitCommand(ctx, "rev-parse", "--git-dir")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return false, nil
@@ -343,8 +446,7 @@ func (m *Manager) isOutsideGitRepo(ctx context.Context) (bool, error) {
 }
 
 func (m *Manager) runGit(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, m.gitBinary, args...)
-	cmd.Dir = m.baseDir
+	cmd := m.gitCommand(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return string(output), nil
@@ -356,4 +458,18 @@ func (m *Manager) runGit(ctx context.Context, args ...string) (string, error) {
 	}
 
 	return string(output), fmt.Errorf("git %s failed: %w; output: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+}
+
+func (m *Manager) gitCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, m.gitBinary, args...)
+	cmd.Dir = m.baseDir
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "LC_ALL=") || strings.HasPrefix(entry, "LANG=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	cmd.Env = append(env, "LC_ALL=C", "LANG=C")
+	return cmd
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -87,12 +87,15 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	// If the base directory is not a git repo, create a plain directory
 	// instead of a git worktree. This is needed for tests and ephemeral
-	// environments that do not have a git repository.
-	gitErr := m.runGitQuick(ctx, "rev-parse", "--git-dir")
+	// environments that do not have a git repository. Only a definitive
+	// "not a git repository" answer takes this path — any other rev-parse
+	// failure (transient IO error, canceled context) used to silently create
+	// a plain dir INSIDE a real repo, confusing worktree bookkeeping later.
+	notRepo, gitErr := m.isOutsideGitRepo(ctx)
 	if gitErr != nil {
-		if errors.Is(gitErr, exec.ErrNotFound) {
-			return "", fmt.Errorf("git executable not found: %w", gitErr)
-		}
+		return "", gitErr
+	}
+	if notRepo {
 		if err := os.MkdirAll(workspacePath, 0o755); err != nil {
 			return "", fmt.Errorf("create plain workspace dir for issue %s: %w", issue.ID, err)
 		}
@@ -317,21 +320,26 @@ func resolvedAbs(path string) string {
 	return abs
 }
 
-// isGitRepo returns true when the base directory is inside a git repository
-// and the git binary is available.
-func (m *Manager) isGitRepo(ctx context.Context) bool {
-	_, err := m.runGit(ctx, "rev-parse", "--git-dir")
-	return err == nil
-}
-
-// runGitQuick is like runGit but returns exec.ErrNotFound directly when the
-// git binary is missing, without wrapping, so callers can distinguish
-// "binary missing" from "command failed".
-func (m *Manager) runGitQuick(ctx context.Context, args ...string) error {
-	cmd := exec.CommandContext(ctx, m.gitBinary, args...)
+// isOutsideGitRepo reports whether baseDir is definitively outside any git
+// repository. A missing git binary or any other rev-parse failure is returned
+// as an error rather than treated as "outside" — failing closed here keeps a
+// transient error inside a real repo from downgrading the workspace to a
+// plain directory.
+func (m *Manager) isOutsideGitRepo(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, m.gitBinary, "rev-parse", "--git-dir")
 	cmd.Dir = m.baseDir
-	_, err := cmd.CombinedOutput()
-	return err
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return false, nil
+	}
+	var execErr *exec.Error
+	if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
+		return false, fmt.Errorf("git executable not found: %w", err)
+	}
+	if strings.Contains(string(output), "not a git repository") {
+		return true, nil
+	}
+	return false, fmt.Errorf("git rev-parse --git-dir failed: %w; output: %s", err, strings.TrimSpace(string(output)))
 }
 
 func (m *Manager) runGit(ctx context.Context, args ...string) (string, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -59,6 +59,24 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	workspacePath := m.workspacePath(issue.ID)
 
+	// Establish the repository mode before inspecting an existing workspace.
+	// In plain-directory mode, an existing path is a valid workspace (not an
+	// unregistered worktree) and must be preserved. Inspecting it with
+	// `git worktree list` first turns that normal case into a false failure.
+	notRepo, gitErr := m.isOutsideGitRepo(ctx)
+	if gitErr != nil {
+		return "", gitErr
+	}
+	if notRepo {
+		if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+			return "", fmt.Errorf("create plain workspace dir for issue %s: %w", issue.ID, err)
+		}
+		m.mu.Lock()
+		m.active[issue.ID] = workspacePath
+		m.mu.Unlock()
+		return workspacePath, nil
+	}
+
 	m.mu.RLock()
 	trackedPath, tracked := m.active[issue.ID]
 	m.mu.RUnlock()
@@ -101,26 +119,6 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 
 	if err := os.MkdirAll(filepath.Dir(workspacePath), 0o755); err != nil {
 		return "", fmt.Errorf("create workspace parent directory: %w", err)
-	}
-
-	// If the base directory is not a git repo, create a plain directory
-	// instead of a git worktree. This is needed for tests and ephemeral
-	// environments that do not have a git repository. Only a definitive
-	// "not a git repository" answer takes this path — any other rev-parse
-	// failure (transient IO error, canceled context) used to silently create
-	// a plain dir INSIDE a real repo, confusing worktree bookkeeping later.
-	notRepo, gitErr := m.isOutsideGitRepo(ctx)
-	if gitErr != nil {
-		return "", gitErr
-	}
-	if notRepo {
-		if err := os.MkdirAll(workspacePath, 0o755); err != nil {
-			return "", fmt.Errorf("create plain workspace dir for issue %s: %w", issue.ID, err)
-		}
-		m.mu.Lock()
-		m.active[issue.ID] = workspacePath
-		m.mu.Unlock()
-		return workspacePath, nil
 	}
 
 	// Choose the branch the agent will commit on. Issue.BranchName is the

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -112,19 +112,19 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 	}
 
 	// Primary: create-and-checkout a brand-new branch.
-	// Fallback 1: branch already exists (-B re-creates and points at HEAD).
-	// Fallback 2: branch exists and we want to attach existing branch as-is.
+	// Fallback: the branch already exists (retry after a partial run, resumed
+	// issue) — attach the worktree to it as-is so the agent's prior commits
+	// stay on the branch ref. Never fall back to `worktree add -B`: it
+	// re-creates the branch AT HEAD, silently discarding those commits and
+	// defeating branch-advance verification.
 	primaryOut, primaryErr := m.runGit(ctx, "worktree", "add", "-b", branchName, workspacePath)
 	if primaryErr != nil {
-		_, recreateErr := m.runGit(ctx, "worktree", "add", "-B", branchName, workspacePath)
-		if recreateErr != nil {
-			_, attachErr := m.runGit(ctx, "worktree", "add", workspacePath, branchName)
-			if attachErr != nil {
-				return "", fmt.Errorf(
-					"create git worktree for issue %s on branch %s: primary -b failed: %v (output=%s); -B retry failed: %v; attach existing branch failed: %w",
-					issue.ID, branchName, primaryErr, primaryOut, recreateErr, attachErr,
-				)
-			}
+		_, attachErr := m.runGit(ctx, "worktree", "add", workspacePath, branchName)
+		if attachErr != nil {
+			return "", fmt.Errorf(
+				"create git worktree for issue %s on branch %s: primary -b failed: %v (output=%s); attach existing branch failed: %w",
+				issue.ID, branchName, primaryErr, primaryOut, attachErr,
+			)
 		}
 	}
 
@@ -147,6 +147,11 @@ func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
 	if issueID == "" {
 		return nil
 	}
+	// Mirror Create's validation: issueID is joined into a filesystem path
+	// below and, on the plain-directory fallback, passed to os.RemoveAll.
+	if !issueIDPattern.MatchString(issueID) {
+		return fmt.Errorf("issue id %q contains invalid characters", issueID)
+	}
 
 	unlock := m.lockIssue(issueID)
 	defer unlock()
@@ -162,8 +167,15 @@ func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
 
 	output, err := m.runGit(ctx, "worktree", "remove", workspacePath, "--force")
 	if err != nil {
-		if !strings.Contains(output, "is not a working tree") {
+		if !isNotAWorktreeError(output) {
 			return fmt.Errorf("remove git worktree for issue %s: %w", issueID, err)
+		}
+		// Plain-directory workspace: created by the non-git fallback in
+		// Create, or a stale dir inside a repo. `git worktree remove` can't
+		// delete it, so remove it directly — otherwise these accumulate
+		// forever (and Cleanup errors every time in non-git mode).
+		if err := os.RemoveAll(workspacePath); err != nil {
+			return fmt.Errorf("remove plain workspace dir for issue %s: %w", issueID, err)
 		}
 	}
 
@@ -173,6 +185,15 @@ func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
 	m.issueLocks.Delete(issueID)
 
 	return nil
+}
+
+// isNotAWorktreeError matches the two `git worktree remove` failures that mean
+// the path is a plain directory rather than a registered worktree: removing a
+// non-worktree path inside a repo ("is not a working tree") and running
+// outside any repo at all ("not a git repository", the non-git fallback mode).
+func isNotAWorktreeError(output string) bool {
+	return strings.Contains(output, "is not a working tree") ||
+		strings.Contains(output, "not a git repository")
 }
 
 // CleanupAll snapshots issue IDs tracked at the call start and cleans up only

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -111,19 +111,21 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 		branchName = issue.ID
 	}
 
-	// Primary: create-and-checkout a brand-new branch.
-	// Fallback: the branch already exists (retry after a partial run, resumed
-	// issue) — attach the worktree to it as-is so the agent's prior commits
-	// stay on the branch ref. Never fall back to `worktree add -B`: it
-	// re-creates the branch AT HEAD, silently discarding those commits and
-	// defeating branch-advance verification.
-	primaryOut, primaryErr := m.runGit(ctx, "worktree", "add", "-b", branchName, workspacePath)
-	if primaryErr != nil {
-		_, attachErr := m.runGit(ctx, "worktree", "add", workspacePath, branchName)
-		if attachErr != nil {
+	if err := m.addWorktree(ctx, branchName, workspacePath); err != nil {
+		// A worktree registration whose directory was deleted externally
+		// (rm -rf without `worktree remove`) blocks every `worktree add` at
+		// this path until pruned. Prune stale registrations once and retry
+		// before giving up — otherwise the issue is permanently undispatchable.
+		if _, pruneErr := m.runGit(ctx, "worktree", "prune"); pruneErr != nil {
 			return "", fmt.Errorf(
-				"create git worktree for issue %s on branch %s: primary -b failed: %v (output=%s); attach existing branch failed: %w",
-				issue.ID, branchName, primaryErr, primaryOut, attachErr,
+				"create git worktree for issue %s on branch %s: %w (git worktree prune also failed: %v)",
+				issue.ID, branchName, err, pruneErr,
+			)
+		}
+		if retryErr := m.addWorktree(ctx, branchName, workspacePath); retryErr != nil {
+			return "", fmt.Errorf(
+				"create git worktree for issue %s on branch %s (after prune): %w",
+				issue.ID, branchName, retryErr,
 			)
 		}
 	}
@@ -141,6 +143,26 @@ func (m *Manager) Create(ctx context.Context, issue types.Issue) (string, error)
 	m.mu.Unlock()
 
 	return workspacePath, nil
+}
+
+// addWorktree creates the worktree on a brand-new branch, falling back to
+// attaching the existing branch as-is (retry after a partial run, resumed
+// issue) so the agent's prior commits stay on the branch ref. Never falls
+// back to `worktree add -B`: it re-creates the branch AT HEAD, silently
+// discarding those commits and defeating branch-advance verification.
+func (m *Manager) addWorktree(ctx context.Context, branchName, workspacePath string) error {
+	primaryOut, primaryErr := m.runGit(ctx, "worktree", "add", "-b", branchName, workspacePath)
+	if primaryErr == nil {
+		return nil
+	}
+	_, attachErr := m.runGit(ctx, "worktree", "add", workspacePath, branchName)
+	if attachErr != nil {
+		return fmt.Errorf(
+			"primary -b failed: %v (output=%s); attach existing branch failed: %w",
+			primaryErr, primaryOut, attachErr,
+		)
+	}
+	return nil
 }
 
 func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
@@ -161,7 +183,6 @@ func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
 		m.mu.Lock()
 		delete(m.active, issueID)
 		m.mu.Unlock()
-		m.issueLocks.Delete(issueID)
 		return nil
 	}
 
@@ -182,7 +203,6 @@ func (m *Manager) Cleanup(ctx context.Context, issueID string) error {
 	m.mu.Lock()
 	delete(m.active, issueID)
 	m.mu.Unlock()
-	m.issueLocks.Delete(issueID)
 
 	return nil
 }
@@ -244,6 +264,11 @@ func (m *Manager) workspacePath(issueID string) string {
 	return filepath.Join(m.baseDir, "workspaces", issueID)
 }
 
+// lockIssue serializes Create/Cleanup per issue ID. Lock entries are never
+// deleted: removing one from Cleanup races a concurrent lockIssue that
+// already loaded the entry, letting two goroutines hold "the" lock for the
+// same issue at once. The map is bounded by the number of distinct issue IDs
+// seen in the process lifetime, which is small.
 func (m *Manager) lockIssue(issueID string) func() {
 	issueLock, _ := m.issueLocks.LoadOrStore(issueID, &sync.Mutex{})
 	mu := issueLock.(*sync.Mutex)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -312,6 +312,103 @@ func TestManager_CleanupNotAWorkingTree(t *testing.T) {
 	assert.False(t, mgr.Exists(issueID))
 }
 
+// TestManager_CreateReattachesExistingBranchWithCommits pins the retry
+// contract: when the per-issue branch already exists with commits from a
+// previous run, Create must attach the worktree to it as-is. The old `-B`
+// fallback re-created the branch at HEAD, silently discarding the agent's
+// commits and defeating branch-advance verification.
+func TestManager_CreateReattachesExistingBranchWithCommits(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	mgr := NewManager(repoDir)
+	ctx := context.Background()
+
+	issue := types.Issue{ID: "ISSUE-RETRY", BranchName: "symphony/issue-retry"}
+	path, err := mgr.Create(ctx, issue)
+	require.NoError(t, err)
+
+	// Simulate agent work: a commit on the issue branch inside the worktree.
+	workPath := filepath.Join(path, "work.txt")
+	require.NoError(t, os.WriteFile(workPath, []byte("agent progress"), 0o644))
+	runGit(t, path, "add", "work.txt")
+	runGit(t, path, "commit", "-m", "agent progress")
+
+	branchRevBefore := gitRevParse(t, path, "symphony/issue-retry")
+
+	// Worktree torn down (crash cleanup, resumed issue) — the branch survives.
+	require.NoError(t, mgr.Cleanup(ctx, issue.ID))
+	assert.NoDirExists(t, path)
+
+	secondPath, err := mgr.Create(ctx, issue)
+	require.NoError(t, err)
+	assert.Equal(t, path, secondPath)
+
+	branchRevAfter := gitRevParse(t, secondPath, "symphony/issue-retry")
+	assert.Equal(t, branchRevBefore, branchRevAfter,
+		"re-creating the workspace must not move the issue branch ref")
+	assert.FileExists(t, filepath.Join(secondPath, "work.txt"),
+		"the agent's prior commit must be checked out in the re-attached worktree")
+}
+
+// TestManager_CleanupRemovesPlainDirOutsideGitRepo pins the non-git fallback
+// contract: Cleanup must delete plain-directory workspaces instead of
+// erroring on `git worktree remove` and leaving them to accumulate forever.
+func TestManager_CleanupRemovesPlainDirOutsideGitRepo(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir() // not a git repository
+	mgr := NewManager(baseDir)
+	ctx := context.Background()
+
+	path, err := mgr.Create(ctx, types.Issue{ID: "ISSUE-PLAIN"})
+	require.NoError(t, err)
+	assert.DirExists(t, path)
+
+	require.NoError(t, mgr.Cleanup(ctx, "ISSUE-PLAIN"))
+	assert.NoDirExists(t, path)
+	assert.False(t, mgr.Exists("ISSUE-PLAIN"))
+}
+
+// TestManager_CleanupRemovesStalePlainDirInsideRepo covers the in-repo
+// variant: a bare directory at the workspace path (left by a crashed run) is
+// not a registered worktree, so `git worktree remove` refuses it — Cleanup
+// must still delete it.
+func TestManager_CleanupRemovesStalePlainDirInsideRepo(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	mgr := NewManager(repoDir)
+	ctx := context.Background()
+
+	workspacePath := filepath.Join(repoDir, "workspaces", "ISSUE-BARE")
+	require.NoError(t, os.MkdirAll(workspacePath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspacePath, "leftover.txt"), []byte("x"), 0o644))
+
+	require.NoError(t, mgr.Cleanup(ctx, "ISSUE-BARE"))
+	assert.NoDirExists(t, workspacePath)
+}
+
+func TestManager_CleanupRejectsInvalidIssueID(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(t.TempDir())
+
+	err := mgr.Cleanup(context.Background(), "../escape")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid characters")
+}
+
+func gitRevParse(t *testing.T, dir string, ref string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git rev-parse %s failed: %s", ref, string(output))
+	return strings.TrimSpace(string(output))
+}
+
 func TestManager_CreateContextCancelled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -370,6 +370,26 @@ func TestManager_CleanupRemovesPlainDirOutsideGitRepo(t *testing.T) {
 	assert.False(t, mgr.Exists("ISSUE-PLAIN"))
 }
 
+// TestManager_CreateReusesExistingPlainDirOutsideGitRepo protects the
+// team-runner path, which prepares worker directories before the workspace
+// manager sees them. Outside a Git repository those directories are valid
+// plain workspaces, not stale in-repo worktree remnants.
+func TestManager_CreateReusesExistingPlainDirOutsideGitRepo(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir() // not a git repository
+	issue := types.Issue{ID: "ISSUE-PLAIN-EXISTING"}
+	path := filepath.Join(baseDir, "workspaces", issue.ID)
+	marker := filepath.Join(path, "prepared.txt")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	require.NoError(t, os.WriteFile(marker, []byte("preserve me"), 0o644))
+
+	createdPath, err := NewManager(baseDir).Create(context.Background(), issue)
+	require.NoError(t, err)
+	assert.Equal(t, path, createdPath)
+	assert.FileExists(t, marker)
+}
+
 // TestManager_CleanupRemovesStalePlainDirInsideRepo covers the in-repo
 // variant: a bare directory at the workspace path (left by a crashed run) is
 // not a registered worktree, so `git worktree remove` refuses it — Cleanup

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -389,6 +389,30 @@ func TestManager_CleanupRemovesStalePlainDirInsideRepo(t *testing.T) {
 	assert.NoDirExists(t, workspacePath)
 }
 
+// TestManager_CreateRecoversRegisteredButMissingWorktree pins the prune-retry
+// path: when the workspace directory is deleted externally (rm -rf without
+// `git worktree remove`), the stale registration blocks every `worktree add`
+// at that path. Create must prune and retry instead of failing forever.
+func TestManager_CreateRecoversRegisteredButMissingWorktree(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	mgr := NewManager(repoDir)
+	ctx := context.Background()
+
+	issue := types.Issue{ID: "ISSUE-GONE", BranchName: "symphony/issue-gone"}
+	path, err := mgr.Create(ctx, issue)
+	require.NoError(t, err)
+
+	// Delete the directory without telling git — the registration remains.
+	require.NoError(t, os.RemoveAll(path))
+
+	secondPath, err := mgr.Create(ctx, issue)
+	require.NoError(t, err, "Create must prune the stale registration and retry")
+	assert.Equal(t, path, secondPath)
+	assert.DirExists(t, secondPath)
+}
+
 func TestManager_CleanupRejectsInvalidIssueID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -413,6 +413,136 @@ func TestManager_CreateRecoversRegisteredButMissingWorktree(t *testing.T) {
 	assert.DirExists(t, secondPath)
 }
 
+func TestManager_CreateRebuildsRecreatedBareRegisteredWorktree(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	issue := types.Issue{ID: "ISSUE-RECREATED", BranchName: "symphony/issue-recreated"}
+	path, err := NewManager(repoDir).Create(context.Background(), issue)
+	require.NoError(t, err)
+
+	// Leave Git's registration behind, then recreate only a plain directory at
+	// the same path. A restarted manager must not accept it as a worktree.
+	require.NoError(t, os.RemoveAll(path))
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	staleFile := filepath.Join(path, "stale.txt")
+	require.NoError(t, os.WriteFile(staleFile, []byte("not a worktree"), 0o644))
+
+	rebuiltPath, err := NewManager(repoDir).Create(context.Background(), issue)
+	require.NoError(t, err)
+	assert.Equal(t, path, rebuiltPath)
+	assert.NoFileExists(t, staleFile)
+	gitFile, err := os.ReadFile(filepath.Join(rebuiltPath, ".git"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(gitFile)), "gitdir: "))
+}
+
+func TestManager_CreateDoesNotDeleteWorkspaceOnRegistrationLookupFailure(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	issue := types.Issue{ID: "ISSUE-LOOKUP", BranchName: "symphony/issue-lookup"}
+	path, err := NewManager(repoDir).Create(context.Background(), issue)
+	require.NoError(t, err)
+	marker := filepath.Join(path, "uncommitted-work.txt")
+	require.NoError(t, os.WriteFile(marker, []byte("preserve me"), 0o644))
+
+	gitPath, err := exec.LookPath("git")
+	require.NoError(t, err)
+	fakeGitPath := filepath.Join(t.TempDir(), "fail-worktree-list.sh")
+	writeFakeGit(t, fakeGitPath, "#!/bin/sh\n"+
+		"if [ \"$1\" = \"worktree\" ] && [ \"$2\" = \"list\" ]; then\n"+
+		"  echo \"temporary git failure\" >&2\n"+
+		"  exit 1\n"+
+		"fi\n"+
+		"exec \""+gitPath+"\" \"$@\"\n")
+
+	resumed := NewManager(repoDir)
+	resumed.gitBinary = fakeGitPath
+	_, err = resumed.Create(context.Background(), issue)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "verify existing workspace")
+	assert.FileExists(t, marker)
+}
+
+func TestManager_CreateCancelledDoesNotDeleteExistingWorkspace(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	issue := types.Issue{ID: "ISSUE-CANCELLED", BranchName: "symphony/issue-cancelled"}
+	path, err := NewManager(repoDir).Create(context.Background(), issue)
+	require.NoError(t, err)
+	marker := filepath.Join(path, "uncommitted-work.txt")
+	require.NoError(t, os.WriteFile(marker, []byte("preserve me"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = NewManager(repoDir).Create(ctx, issue)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.FileExists(t, marker)
+}
+
+func TestManager_CreateDoesNotPruneForUnrelatedAddFailure(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepo(t)
+	gitPath, err := exec.LookPath("git")
+	require.NoError(t, err)
+	pruneMarker := filepath.Join(t.TempDir(), "pruned")
+	fakeGitPath := filepath.Join(t.TempDir(), "fail-add.sh")
+	writeFakeGit(t, fakeGitPath, "#!/bin/sh\n"+
+		"if [ \"$1\" = \"worktree\" ] && [ \"$2\" = \"add\" ]; then\n"+
+		"  echo \"synthetic add failure\" >&2\n"+
+		"  exit 1\n"+
+		"fi\n"+
+		"if [ \"$1\" = \"worktree\" ] && [ \"$2\" = \"prune\" ]; then\n"+
+		"  touch \""+pruneMarker+"\"\n"+
+		"  exit 0\n"+
+		"fi\n"+
+		"exec \""+gitPath+"\" \"$@\"\n")
+
+	mgr := NewManager(repoDir)
+	mgr.gitBinary = fakeGitPath
+	_, err = mgr.Create(context.Background(), types.Issue{ID: "ISSUE-ADD-FAIL"})
+	require.Error(t, err)
+	assert.NoFileExists(t, pruneMarker)
+}
+
+func TestManager_LockIssueReclaimsIdleEntry(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(t.TempDir())
+	unlock := mgr.lockIssue("ISSUE-LOCK")
+	mgr.issueLocksMu.Lock()
+	assert.Len(t, mgr.issueLocks, 1)
+	mgr.issueLocksMu.Unlock()
+
+	unlock()
+	mgr.issueLocksMu.Lock()
+	assert.Empty(t, mgr.issueLocks)
+	mgr.issueLocksMu.Unlock()
+}
+
+func TestManager_GitCommandsUseCLocale(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	fakeGitPath := filepath.Join(t.TempDir(), "locale-aware-git.sh")
+	writeFakeGit(t, fakeGitPath, "#!/bin/sh\n"+
+		"if [ \"$LC_ALL\" != \"C\" ] || [ \"$LANG\" != \"C\" ]; then\n"+
+		"  echo \"git: no es un repositorio\" >&2\n"+
+		"  exit 1\n"+
+		"fi\n"+
+		"echo \"fatal: not a git repository\" >&2\n"+
+		"exit 128\n")
+
+	mgr := NewManager(baseDir)
+	mgr.gitBinary = fakeGitPath
+	path, err := mgr.Create(context.Background(), types.Issue{ID: "ISSUE-LOCALE"})
+	require.NoError(t, err)
+	assert.DirExists(t, path)
+}
+
 func TestManager_CleanupRejectsInvalidIssueID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part 2/3 of the full-codebase audit fix plan (`.omc/plans/2026-07-16-contrabass-audit-fix-plan.md`).

## P0

- **`worktree add -B` silently reset existing issue branches to HEAD.** On a retry/resume where the per-issue branch already had agent commits, the `-b → -B → attach` fallback chain discarded those commits from the branch ref, defeating branch-advance verification. The fallback is now attach-existing only; `-B` is gone.
- **Cleanup never removed plain-directory workspaces.** In-repo stale dirs were tolerated but never deleted; in non-git mode Cleanup errored on every call while workspaces accumulated forever. Cleanup now falls back to `os.RemoveAll` when git reports the path is not a working tree / not in a repository, and validates `issueID` (mirroring Create) before joining it into a path.

## P1

- A worktree registration whose directory was deleted externally (`rm -rf` without `worktree remove`) blocked every `worktree add` at that path → the issue became permanently undispatchable. Create now runs `git worktree prune` once and retries.
- Cleanup deleted its per-issue lock entry, racing a concurrent `lockIssue` — two goroutines could Create the same issue simultaneously. Lock entries are now retained (bounded by distinct issue IDs).

## P2

- The non-git plain-dir fallback triggered on ANY `git rev-parse` failure — a transient error inside a real repo silently downgraded the workspace to a plain dir. It now requires git's explicit "not a git repository" answer and fails closed otherwise. Dead `isGitRepo` removed.

## Tests

`go test ./internal/workspace/ ./internal/orchestrator/` green. New: `TestManager_CreateReattachesExistingBranchWithCommits`, `TestManager_CleanupRemovesPlainDirOutsideGitRepo`, `TestManager_CleanupRemovesStalePlainDirInsideRepo`, `TestManager_CleanupRejectsInvalidIssueID`, `TestManager_CreateRecoversRegisteredButMissingWorktree`.