### PR TITLE
fix(agent): drain opencode stdout, split team CLI streams, unrace codex Stop

### DIFF
--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -69,10 +69,17 @@ type CodexRunnerOptions struct {
 }
 
 type codexProcess struct {
-	cmd        *exec.Cmd
-	stdin      io.WriteCloser
-	streamCtx  context.Context
-	done       chan error
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	streamCtx context.Context
+	// done delivers the exit error to the AgentProcess.Done consumer (the
+	// orchestrator). It carries exactly one value; nothing else may receive
+	// from it, or the real exit error is swallowed and the consumer sees a
+	// nil from the closed channel instead.
+	done chan error
+	// exited is closed after done is populated. Internal waiters (Stop) block
+	// on this instead of done so they never steal the consumer's error.
+	exited     chan struct{}
 	stderr     *safeBuffer
 	stderrDone chan struct{}
 
@@ -114,6 +121,7 @@ func (p *codexProcess) finish(err error) {
 	p.doneOnce.Do(func() {
 		p.done <- err
 		close(p.done)
+		close(p.exited)
 	})
 }
 
@@ -297,6 +305,7 @@ func (r *CodexRunner) Start(ctx context.Context, issue types.Issue, workspace st
 		stdin:      stdin,
 		streamCtx:  ctx,
 		done:       make(chan error, 1),
+		exited:     make(chan struct{}),
 		stderr:     stderrBuf,
 		stderrDone: stderrDone,
 	}
@@ -416,11 +425,12 @@ func (r *CodexRunner) Stop(proc *AgentProcess) error {
 		return fmt.Errorf("%w: interrupt process: %w", errCodexStopFailed, err)
 	}
 
+	// Wait on exited, never on done: done carries the exit error for the
+	// AgentProcess.Done consumer, and receiving here would steal that value —
+	// the orchestrator would see a nil from the closed channel and record a
+	// failed run as clean.
 	select {
-	case doneErr := <-state.done:
-		if doneErr != nil && !errors.Is(doneErr, os.ErrProcessDone) {
-			r.logger.Warn("codex process exited with error during stop", "pid", proc.PID, "err", doneErr)
-		}
+	case <-state.exited:
 		return nil
 	case <-time.After(r.handshakeTimeout):
 		if state.cmd.Process == nil {
@@ -433,10 +443,7 @@ func (r *CodexRunner) Stop(proc *AgentProcess) error {
 			return fmt.Errorf("%w: kill process: %w", errCodexStopFailed, err)
 		}
 		select {
-		case doneErr := <-state.done:
-			if doneErr != nil && !errors.Is(doneErr, os.ErrProcessDone) {
-				r.logger.Warn("codex process exited with error after kill", "pid", proc.PID, "err", doneErr)
-			}
+		case <-state.exited:
 			return nil
 		case <-time.After(r.handshakeTimeout):
 			return fmt.Errorf("%w: timeout after kill", errCodexStopFailed)

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -763,6 +763,7 @@ func startedExitedCodexProcessWithStdin(t *testing.T, ctx context.Context) (*cod
 		stdin:      stdin,
 		streamCtx:  ctx,
 		done:       make(chan error, 1),
+		exited:     make(chan struct{}),
 		stderr:     &safeBuffer{},
 		stderrDone: stderrDone,
 	}, stdin
@@ -832,6 +833,7 @@ func startedExitedCodexProcess(t *testing.T, ctx context.Context) *codexProcess 
 		cmd:        cmd,
 		streamCtx:  ctx,
 		done:       make(chan error, 1),
+		exited:     make(chan struct{}),
 		stderr:     &safeBuffer{},
 		stderrDone: stderrDone,
 	}

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const wireCaptureHandshakeTimeout = 5 * time.Second
+
 func TestCodexRunner_PolicyDefaults_OnWire(t *testing.T) {
-	runner := NewCodexRunner(helperCommand(t, "capture-wire"), 2*time.Second)
+	runner := NewCodexRunner(helperCommand(t, "capture-wire"), wireCaptureHandshakeTimeout)
 
 	proc, err := runner.Start(context.Background(), types.Issue{ID: "MT-11", Title: "Task 11"}, t.TempDir(), "hello")
 	require.NoError(t, err)
@@ -42,7 +44,7 @@ func TestCodexRunner_PolicyDefaults_OnWire(t *testing.T) {
 }
 
 func TestCodexRunner_PolicyOverride_OnWire(t *testing.T) {
-	runner := NewCodexRunner(helperCommand(t, "capture-wire"), 2*time.Second)
+	runner := NewCodexRunner(helperCommand(t, "capture-wire"), wireCaptureHandshakeTimeout)
 	runner.ConfigureCodex(CodexRunnerOptions{
 		ApprovalPolicy: "on-request",
 		Sandbox:        map[string]interface{}{"type": "readOnly"},
@@ -98,7 +100,7 @@ func TestCodexRunner_PolicyStringOverride_OnWire(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			runner := NewCodexRunner(helperCommand(t, "capture-wire"), 2*time.Second)
+			runner := NewCodexRunner(helperCommand(t, "capture-wire"), wireCaptureHandshakeTimeout)
 			runner.ConfigureCodex(CodexRunnerOptions{Sandbox: c.sandbox})
 
 			proc, err := runner.Start(context.Background(), types.Issue{ID: "MT-11", Title: "Task 11"}, t.TempDir(), "hello")
@@ -405,7 +407,10 @@ func TestCodexRunner_ConcurrentStartStop(t *testing.T) {
 			}
 
 			select {
-			case <-proc.Done:
+			case doneErr := <-proc.Done:
+				if doneErr == nil {
+					errCh <- errors.New("Stop consumed the codex exit error")
+				}
 			case <-time.After(2 * time.Second):
 				errCh <- errors.New("done timed out")
 			}

--- a/internal/agent/omx_test.go
+++ b/internal/agent/omx_test.go
@@ -527,6 +527,11 @@ args = sys.argv[1:]
 with open(log_path, 'a', encoding='utf-8') as fh:
     fh.write(' '.join(args) + '\n')
 
+# Real omx/omc are Node CLIs that emit runtime warnings on stderr. Mixing
+# stderr into the parsed output used to corrupt the JSON envelopes and shut
+# down healthy teams, so every fixture invocation exercises that noise.
+print('(node:99999) ExperimentalWarning: contrabass fixture noise', file=sys.stderr)
+
 def post(path, payload):
     data = json.dumps(payload).encode('utf-8')
     req = urllib.request.Request(base + path, data=data, headers={'Content-Type': 'application/json'})

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -197,6 +197,10 @@ func (r *OpenCodeRunner) ensureServer(ctx context.Context, workDir string) (stri
 	key := serverKey(workDir)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return "", 0, err
+		}
+
 		r.mu.Lock()
 		if server, ok := r.servers[key]; ok && server != nil {
 			if server.ready != nil {
@@ -214,20 +218,45 @@ func (r *OpenCodeRunner) ensureServer(ctx context.Context, workDir string) (stri
 				pid := serverPID(server)
 				url := server.url
 				r.mu.Unlock()
-				if r.serverHealthy(ctx, url) {
+				healthy, healthErr := r.serverHealthy(ctx, url)
+				if healthErr != nil {
+					return "", 0, healthErr
+				}
+				if healthy {
 					return url, pid, nil
 				}
 				// The cached server died or wedged: without this reap its
 				// stale URL would be reused by every future Start, and each
-				// session would hang until timeout. Drop the entry, make sure
-				// the process is gone, and start a fresh server.
+				// session would hang until timeout. Replace it with a startup
+				// placeholder before reaping so concurrent callers wait rather
+				// than racing a replacement onto the old server's port.
 				r.mu.Lock()
-				if current, ok := r.servers[key]; ok && current == server {
-					delete(r.servers, key)
+				if err := ctx.Err(); err != nil {
+					r.mu.Unlock()
+					return "", 0, err
 				}
+				current, stillCurrent := r.servers[key]
+				if !stillCurrent || current != server {
+					r.mu.Unlock()
+					continue
+				}
+				argv := strings.Fields(strings.TrimSpace(r.binaryPath))
+				if len(argv) == 0 {
+					r.mu.Unlock()
+					return "", 0, errors.New("opencode binary path is empty")
+				}
+				extraEnv := append([]string(nil), r.extraEnv...)
+				placeholder := &openCodeServer{
+					port:  server.port,
+					ready: make(chan struct{}),
+				}
+				r.servers[key] = placeholder
 				r.mu.Unlock()
-				_ = r.stopServer(server)
-				continue
+				if err := r.stopServer(ctx, server); err != nil {
+					r.discardStartingServer(key, placeholder)
+					return "", 0, fmt.Errorf("reap unhealthy opencode server: %w", err)
+				}
+				return r.startAndPublishServer(ctx, key, workDir, argv, extraEnv, placeholder)
 			}
 
 			delete(r.servers, key)
@@ -248,39 +277,65 @@ func (r *OpenCodeRunner) ensureServer(ctx context.Context, workDir string) (stri
 		r.servers[key] = placeholder
 		r.mu.Unlock()
 
-		server, err := r.startServer(ctx, argv, workDir, extraEnv, port)
+		return r.startAndPublishServer(ctx, key, workDir, argv, extraEnv, placeholder)
+	}
+}
 
-		r.mu.Lock()
-		current, stillCurrent := r.servers[key]
-		if stillCurrent && current == placeholder {
-			if err != nil {
-				delete(r.servers, key)
-			} else {
-				placeholder.process = server.process
-				placeholder.url = server.url
-			}
-		}
-		ready := placeholder.ready
-		placeholder.ready = nil
-		r.mu.Unlock()
+func (r *OpenCodeRunner) startAndPublishServer(
+	ctx context.Context,
+	key string,
+	workDir string,
+	argv []string,
+	extraEnv []string,
+	placeholder *openCodeServer,
+) (string, int, error) {
+	server, err := r.startServer(ctx, argv, workDir, extraEnv, placeholder.port)
 
-		if ready != nil {
-			close(ready)
-		}
-
-		if !stillCurrent || current != placeholder {
-			if err == nil {
-				_ = r.stopServer(server)
-				return "", 0, errors.New("opencode server startup interrupted")
-			}
-			return "", 0, err
-		}
-
+	r.mu.Lock()
+	current, stillCurrent := r.servers[key]
+	if stillCurrent && current == placeholder {
 		if err != nil {
-			return "", 0, err
+			delete(r.servers, key)
+		} else {
+			placeholder.process = server.process
+			placeholder.url = server.url
 		}
+	}
+	ready := placeholder.ready
+	placeholder.ready = nil
+	r.mu.Unlock()
 
-		return server.url, serverPID(server), nil
+	if ready != nil {
+		close(ready)
+	}
+
+	if !stillCurrent || current != placeholder {
+		if err == nil {
+			_ = r.stopServer(ctx, server)
+			return "", 0, errors.New("opencode server startup interrupted")
+		}
+		return "", 0, err
+	}
+
+	if err != nil {
+		return "", 0, err
+	}
+
+	return server.url, serverPID(server), nil
+}
+
+func (r *OpenCodeRunner) discardStartingServer(key string, placeholder *openCodeServer) {
+	r.mu.Lock()
+	current, stillCurrent := r.servers[key]
+	if stillCurrent && current == placeholder {
+		delete(r.servers, key)
+	}
+	ready := placeholder.ready
+	placeholder.ready = nil
+	r.mu.Unlock()
+
+	if ready != nil {
+		close(ready)
 	}
 }
 
@@ -379,21 +434,29 @@ func (r *OpenCodeRunner) startServer(
 // serverHealthy reports whether the opencode server at url still accepts
 // connections. Any HTTP response — regardless of status code — counts as
 // healthy; the check only exists to detect a process that exited or stopped
-// serving entirely.
-func (r *OpenCodeRunner) serverHealthy(ctx context.Context, url string) bool {
+// serving entirely. Caller cancellation is returned separately because it is
+// not evidence that a shared server is unhealthy.
+func (r *OpenCodeRunner) serverHealthy(ctx context.Context, url string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, url+"/", nil)
 	if err != nil {
-		return false
+		return false, err
 	}
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
-		return false
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, nil
 	}
 	_ = resp.Body.Close()
-	return true
+	return true, nil
 }
 
 func isSignalError(err error) bool {
@@ -406,7 +469,11 @@ func isSignalError(err error) bool {
 	return exitErr.ExitCode() == -1
 }
 
-func (r *OpenCodeRunner) stopServer(server *openCodeServer) error {
+// stopServer terminates a managed server within the smaller of the caller's
+// remaining deadline and the runner timeout. A SIGKILL is best-effort after
+// the deadline; it is not followed by another full timeout window, so recovery
+// cannot hold a dispatch slot for twice the configured timeout.
+func (r *OpenCodeRunner) stopServer(ctx context.Context, server *openCodeServer) error {
 	if server == nil {
 		return nil
 	}
@@ -415,6 +482,11 @@ func (r *OpenCodeRunner) stopServer(server *openCodeServer) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stopCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
 
 	if err := cmd.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		return fmt.Errorf("interrupt opencode server: %w", err)
@@ -431,14 +503,12 @@ func (r *OpenCodeRunner) stopServer(server *openCodeServer) error {
 			return err
 		}
 		return nil
-	case <-time.After(r.timeout):
+	case <-stopCtx.Done():
 		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 			return fmt.Errorf("kill opencode server: %w", err)
 		}
-		select {
-		case <-waitCh:
-		case <-time.After(r.timeout):
-		}
+		// Wait continues in the background to reap the child; returning now
+		// honors the single shutdown budget for the caller.
 		return nil
 	}
 }
@@ -456,7 +526,7 @@ func (r *OpenCodeRunner) Close() error {
 
 	var closeErr error
 	for _, server := range servers {
-		if err := r.stopServer(server); err != nil && closeErr == nil {
+		if err := r.stopServer(context.Background(), server); err != nil && closeErr == nil {
 			closeErr = err
 		}
 	}
@@ -501,12 +571,18 @@ func (r *OpenCodeRunner) Start(ctx context.Context, _ types.Issue, workspace str
 	// prompt. Submitting first races the subscription: early events —
 	// including the terminal idle status for fast turns — are missed and the
 	// session hangs until timeout.
+	subscriptionTimer := time.NewTimer(r.timeout)
+	defer subscriptionTimer.Stop()
 	select {
 	case <-subscribed:
 	case doneErr := <-done:
 		if doneErr == nil {
 			doneErr = errors.New("opencode event stream closed before subscribing")
 		}
+		return nil, doneErr
+	case <-subscriptionTimer.C:
+		doneErr := fmt.Errorf("timed out waiting for opencode event stream subscription after %s", r.timeout)
+		finish(doneErr)
 		return nil, doneErr
 	case <-ctx.Done():
 		finish(ctx.Err())

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -212,8 +212,22 @@ func (r *OpenCodeRunner) ensureServer(ctx context.Context, workDir string) (stri
 
 			if server.url != "" {
 				pid := serverPID(server)
+				url := server.url
 				r.mu.Unlock()
-				return server.url, pid, nil
+				if r.serverHealthy(ctx, url) {
+					return url, pid, nil
+				}
+				// The cached server died or wedged: without this reap its
+				// stale URL would be reused by every future Start, and each
+				// session would hang until timeout. Drop the entry, make sure
+				// the process is gone, and start a fresh server.
+				r.mu.Lock()
+				if current, ok := r.servers[key]; ok && current == server {
+					delete(r.servers, key)
+				}
+				r.mu.Unlock()
+				_ = r.stopServer(server)
+				continue
 			}
 
 			delete(r.servers, key)
@@ -362,6 +376,26 @@ func (r *OpenCodeRunner) startServer(
 	}
 }
 
+// serverHealthy reports whether the opencode server at url still accepts
+// connections. Any HTTP response — regardless of status code — counts as
+// healthy; the check only exists to detect a process that exited or stopped
+// serving entirely.
+func (r *OpenCodeRunner) serverHealthy(ctx context.Context, url string) bool {
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(checkCtx, http.MethodGet, url+"/", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
+}
+
 func isSignalError(err error) bool {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
@@ -460,7 +494,24 @@ func (r *OpenCodeRunner) Start(ctx context.Context, _ types.Issue, workspace str
 		})
 	}
 
-	go r.streamSessionEvents(streamCtx, serverURL, sessionID, events, finish)
+	subscribed := make(chan struct{})
+	go r.streamSessionEvents(streamCtx, serverURL, sessionID, events, finish, subscribed)
+
+	// Wait for the SSE subscription to be established before submitting the
+	// prompt. Submitting first races the subscription: early events —
+	// including the terminal idle status for fast turns — are missed and the
+	// session hangs until timeout.
+	select {
+	case <-subscribed:
+	case doneErr := <-done:
+		if doneErr == nil {
+			doneErr = errors.New("opencode event stream closed before subscribing")
+		}
+		return nil, doneErr
+	case <-ctx.Done():
+		finish(ctx.Err())
+		return nil, ctx.Err()
+	}
 
 	if err := r.submitPrompt(ctx, serverURL, sessionID, prompt); err != nil {
 		cancelStream()
@@ -593,6 +644,7 @@ func (r *OpenCodeRunner) streamSessionEvents(
 	sessionID string,
 	events chan<- types.AgentEvent,
 	finish func(error),
+	subscribed chan<- struct{},
 ) {
 	defer finish(nil)
 
@@ -612,6 +664,10 @@ func (r *OpenCodeRunner) streamSessionEvents(
 		finish(fmt.Errorf("opencode event stream failed: status %d body=%q", resp.StatusCode, string(body)))
 		return
 	}
+
+	// The subscription is live: Start may now submit the prompt without
+	// racing early events.
+	close(subscribed)
 
 	reader := newSSEReader(resp.Body)
 	for {

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -256,6 +256,14 @@ func (r *OpenCodeRunner) ensureServer(ctx context.Context, workDir string) (stri
 					r.discardStartingServer(key, placeholder)
 					return "", 0, fmt.Errorf("reap unhealthy opencode server: %w", err)
 				}
+				// stopServer can return after the caller deadline while its
+				// best-effort reap completes in the background. Do not start a
+				// replacement after that deadline: besides violating cancellation,
+				// it could launch an unavailable binary during shutdown.
+				if err := ctx.Err(); err != nil {
+					r.discardStartingServer(key, placeholder)
+					return "", 0, err
+				}
 				return r.startAndPublishServer(ctx, key, workDir, argv, extraEnv, placeholder)
 			}
 

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -320,6 +320,12 @@ func (r *OpenCodeRunner) startServer(
 			if strings.Contains(line, "listening on http://") || strings.Contains(line, "listening on https://") {
 				if url := extractListeningURL(line); url != "" {
 					urlCh <- url
+					// Keep draining stdout for the server's lifetime. Nothing
+					// else reads this pipe: once the server has logged enough
+					// to fill it (~64KB), its writes block and the whole
+					// server freezes, stalling every session on it. Exits on
+					// EOF when the server process ends.
+					_, _ = io.Copy(io.Discard, stdout)
 					return
 				}
 			}

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -71,6 +73,86 @@ func TestOpenCodeRunner_Start(t *testing.T) {
 	assert.Equal(t, "message.part.updated", events[1].Type)
 	assert.Equal(t, "session.status", events[2].Type)
 	assertDoneNil(t, proc.Done)
+}
+
+func TestOpenCodeRunner_StartTimesOutBeforePromptWithoutSSEHeaders(t *testing.T) {
+	streamStarted := make(chan struct{})
+	var promptSubmitted atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			_, _ = io.WriteString(w, `{"id":"sess-1"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/session/sess-1/prompt_async":
+			promptSubmitted.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			close(streamStarted)
+			// Deliberately do not flush response headers. A proxy with this
+			// behavior used to leave Start blocked forever when its caller had
+			// no deadline.
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	workspace := t.TempDir()
+	runner := NewOpenCodeRunner("opencode serve", 0, "", "", 100*time.Millisecond)
+	primeTestOpenCodeServer(runner, workspace, server.URL, 4242)
+
+	start := time.Now()
+	proc, err := runner.Start(context.Background(), types.Issue{}, workspace, "hello")
+	require.Error(t, err)
+	assert.Nil(t, proc)
+	assert.ErrorContains(t, err, "event stream subscription")
+	assert.Less(t, time.Since(start), time.Second)
+	assert.False(t, promptSubmitted.Load())
+
+	select {
+	case <-streamStarted:
+	default:
+		t.Fatal("expected SSE connection attempt before timeout")
+	}
+}
+
+func TestOpenCodeRunner_CancelledHealthCheckKeepsCachedServer(t *testing.T) {
+	healthStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/" {
+			close(healthStarted)
+			<-r.Context().Done()
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	workspace := t.TempDir()
+	runner := NewOpenCodeRunner("opencode serve", 0, "", "", time.Second)
+	key := serverKey(workspace)
+	cached := &openCodeServer{url: server.URL}
+	runner.servers[key] = cached
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := runner.ensureServer(ctx, workspace)
+		result <- err
+	}()
+
+	select {
+	case <-healthStarted:
+	case <-time.After(time.Second):
+		t.Fatal("health check did not start")
+	}
+	cancel()
+
+	require.ErrorIs(t, <-result, context.Canceled)
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	assert.Same(t, cached, runner.servers[key])
 }
 
 func TestOpenCodeRunner_StartWithAuth(t *testing.T) {
@@ -527,6 +609,161 @@ func TestOpenCodeRunner_EnsureServerStartsWorkspacesInParallel(t *testing.T) {
 		"http://127.0.0.1:8787",
 		"http://127.0.0.1:8788",
 	}, []string{res1.url, res2.url})
+}
+
+func TestOpenCodeRunner_ConcurrentStaleRecoveryReapsOnce(t *testing.T) {
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer healthServer.Close()
+
+	stateDir := t.TempDir()
+	scriptPath := filepath.Join(stateDir, "replacement-opencode.sh")
+	script := `#!/bin/sh
+set -eu
+echo "listening on ${TEST_SERVER_URL:?TEST_SERVER_URL is required}"
+sleep 30
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	runner := NewOpenCodeRunner(scriptPath, 0, "", "", time.Second)
+	runner.SetExtraEnv([]string{"TEST_SERVER_URL=" + healthServer.URL})
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+
+	staleCmd := exec.Command("sleep", "30")
+	require.NoError(t, staleCmd.Start())
+	workspace := filepath.Join(stateDir, "workspace")
+	require.NoError(t, os.MkdirAll(workspace, 0o755))
+	runner.servers[serverKey(workspace)] = &openCodeServer{
+		process: staleCmd,
+		url:     "http://127.0.0.1:1",
+	}
+
+	const callers = 8
+	type result struct {
+		url string
+		pid int
+		err error
+	}
+	results := make(chan result, callers)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for range callers {
+		go func() {
+			url, pid, err := runner.ensureServer(ctx, workspace)
+			results <- result{url: url, pid: pid, err: err}
+		}()
+	}
+
+	for range callers {
+		result := <-results
+		require.NoError(t, result.err)
+		assert.Equal(t, healthServer.URL, result.url)
+		assert.NotZero(t, result.pid)
+	}
+	assert.Eventually(t, func() bool {
+		return staleCmd.ProcessState != nil
+	}, time.Second, 10*time.Millisecond, "stale server was not reaped")
+}
+
+func TestOpenCodeRunner_ConcurrentStaleRecoveryWaitsForFixedPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	stateDir := t.TempDir()
+	scriptPath := filepath.Join(stateDir, "port-opencode.py")
+	script := `#!/usr/bin/env python3
+import http.server
+import os
+import signal
+import sys
+
+port = int(sys.argv[sys.argv.index("--port") + 1])
+if os.environ.get("IGNORE_INTERRUPT") == "1":
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+else:
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(204)
+        self.end_headers()
+    def log_message(self, *_):
+        pass
+
+server = http.server.HTTPServer(("127.0.0.1", port), Handler)
+print(f"listening on http://127.0.0.1:{port}", flush=True)
+server.serve_forever()
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	runner := NewOpenCodeRunner("python3 "+scriptPath, port, "", "", 250*time.Millisecond)
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+
+	staleCmd := exec.Command("python3", scriptPath, "--port", strconv.Itoa(port))
+	staleCmd.Env = append(os.Environ(), "IGNORE_INTERRUPT=1")
+	require.NoError(t, staleCmd.Start())
+	assert.Eventually(t, func() bool {
+		conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 20*time.Millisecond)
+		if dialErr != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, time.Second, 10*time.Millisecond, "stale server never bound its configured port")
+
+	workspace := filepath.Join(stateDir, "workspace")
+	require.NoError(t, os.MkdirAll(workspace, 0o755))
+	runner.servers[serverKey(workspace)] = &openCodeServer{
+		process: staleCmd,
+		port:    port,
+		url:     "http://127.0.0.1:1",
+	}
+
+	const callers = 8
+	results := make(chan error, callers)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for range callers {
+		go func() {
+			_, _, ensureErr := runner.ensureServer(ctx, workspace)
+			results <- ensureErr
+		}()
+	}
+
+	for range callers {
+		require.NoError(t, <-results)
+	}
+}
+
+func TestOpenCodeRunner_StaleRecoveryHonorsCallerDeadline(t *testing.T) {
+	// Ignore SIGINT so recovery must use its caller deadline instead of
+	// waiting for the runner's much longer shutdown budget.
+	staleCmd := exec.Command("sh", "-c", "trap '' INT; exec sleep 30")
+	require.NoError(t, staleCmd.Start())
+
+	runner := NewOpenCodeRunner("opencode serve", 0, "", "", 5*time.Second)
+	workspace := t.TempDir()
+	runner.servers[serverKey(workspace)] = &openCodeServer{
+		process: staleCmd,
+		url:     "http://127.0.0.1:1",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := runner.ensureServer(ctx, workspace)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), time.Second)
+	assert.Eventually(t, func() bool {
+		return staleCmd.ProcessState != nil
+	}, time.Second, 10*time.Millisecond, "deadline recovery did not reap stale server")
 }
 
 // TestOpenCodeRunner_DrainsServerStdoutAfterStartup pins the pipe-drain

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -529,6 +529,54 @@ func TestOpenCodeRunner_EnsureServerStartsWorkspacesInParallel(t *testing.T) {
 	}, []string{res1.url, res2.url})
 }
 
+// TestOpenCodeRunner_DrainsServerStdoutAfterStartup pins the pipe-drain
+// contract: after the "listening on" line, nothing used to read the server's
+// stdout, so once the OS pipe buffer (~64KB) filled, the server's log writes
+// blocked and the whole server froze — every session on it stalled. The fake
+// server emits ~512KB of log output (8x the pipe buffer) after startup and
+// then writes a marker file; the marker is only reachable if startServer
+// keeps draining the pipe.
+func TestOpenCodeRunner_DrainsServerStdoutAfterStartup(t *testing.T) {
+	stateDir := t.TempDir()
+	scriptPath := filepath.Join(stateDir, "chatty-opencode.sh")
+	script := `#!/bin/sh
+set -eu
+state_dir="${TEST_STATE_DIR:?TEST_STATE_DIR is required}"
+echo "listening on http://127.0.0.1:4545"
+i=0
+while [ "$i" -lt 512 ]; do
+  printf '%01023d\n' "$i"
+  i=$((i+1))
+done
+touch "$state_dir/drained"
+sleep 30
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	runner := NewOpenCodeRunner(scriptPath, 0, "", "", 5*time.Second)
+	runner.SetExtraEnv([]string{"TEST_STATE_DIR=" + stateDir})
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	workspace := filepath.Join(stateDir, "workspace")
+	require.NoError(t, os.MkdirAll(workspace, 0o755))
+
+	url, pid, err := runner.ensureServer(ctx, workspace)
+	require.NoError(t, err)
+	assert.Equal(t, "http://127.0.0.1:4545", url)
+	assert.NotZero(t, pid)
+
+	assert.Eventually(t, func() bool {
+		_, statErr := os.Stat(filepath.Join(stateDir, "drained"))
+		return statErr == nil
+	}, 8*time.Second, 50*time.Millisecond,
+		"server blocked writing to its undrained stdout pipe")
+}
+
 func newTestOpenCodeRunner(serverURL string) *OpenCodeRunner {
 	r := NewOpenCodeRunner("opencode serve", 0, "", "", 2*time.Second)
 	primeTestOpenCodeServer(r, "", serverURL, 4242)

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -744,9 +744,18 @@ server.serve_forever()
 
 func TestOpenCodeRunner_StaleRecoveryHonorsCallerDeadline(t *testing.T) {
 	// Ignore SIGINT so recovery must use its caller deadline instead of
-	// waiting for the runner's much longer shutdown budget.
-	staleCmd := exec.Command("sh", "-c", "trap '' INT; exec sleep 30")
+	// waiting for the runner's much longer shutdown budget. Wait until the
+	// trap is installed before injecting the process; otherwise CI can signal
+	// the shell during startup, let it exit early, and accidentally start the
+	// unavailable replacement binary.
+	readyFile := filepath.Join(t.TempDir(), "stale-server-ready")
+	staleCmd := exec.Command("sh", "-c", "trap '' INT; : > \"$READY_FILE\"; exec sleep 30")
+	staleCmd.Env = append(os.Environ(), "READY_FILE="+readyFile)
 	require.NoError(t, staleCmd.Start())
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, time.Second, 10*time.Millisecond, "stale server did not install its interrupt trap")
 
 	runner := NewOpenCodeRunner("opencode serve", 0, "", "", 5*time.Second)
 	workspace := t.TempDir()
@@ -761,9 +770,15 @@ func TestOpenCodeRunner_StaleRecoveryHonorsCallerDeadline(t *testing.T) {
 	_, _, err := runner.ensureServer(ctx, workspace)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Less(t, time.Since(start), time.Second)
-	assert.Eventually(t, func() bool {
-		return staleCmd.ProcessState != nil
-	}, time.Second, 10*time.Millisecond, "deadline recovery did not reap stale server")
+
+	// stopServer reaps killed children asynchronously after returning at the
+	// caller deadline. Reading Cmd.ProcessState here races with that Wait; the
+	// observable recovery contract is that this runner no longer retains the
+	// stale server or a replacement placeholder.
+	runner.mu.Lock()
+	_, cached := runner.servers[serverKey(workspace)]
+	runner.mu.Unlock()
+	assert.False(t, cached, "deadline recovery left a stale server cached")
 }
 
 // TestOpenCodeRunner_DrainsServerStdoutAfterStartup pins the pipe-drain

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -628,6 +628,13 @@ func setSSEHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	// Send the headers immediately, as a real SSE server does: Start blocks
+	// prompt submission until the subscription response arrives, so a handler
+	// that defers WriteHeader until its first event would deadlock the test.
+	w.WriteHeader(http.StatusOK)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 func writeSSEEvent(w http.ResponseWriter, eventType, data string) {

--- a/internal/agent/team_restart.go
+++ b/internal/agent/team_restart.go
@@ -26,8 +26,14 @@ type WorkerRestartResult struct {
 	ReassignedTasks []string  `json:"reassigned_tasks,omitempty"`
 }
 
-// RestartWorker attempts to gracefully restart a worker by sending a shutdown
-// request via the CLI API and reassigning its in-progress tasks.
+// RestartWorker gracefully "restarts" a worker: it sends a shutdown request
+// via the CLI API, waits (bounded by GracePeriod) for the acknowledgment, and
+// releases the worker's in-progress task claims so another worker can pick
+// them up. It does NOT spawn a replacement process itself — respawning is the
+// team CLI supervisor's job (omx v0.16+ self-healing). Success=true therefore
+// means "shutdown requested and claims released", not "new worker confirmed
+// running"; when the worker never acknowledges, Error records that while
+// Success stays true because the claim release still proceeded.
 func (r *teamCLIRunner) RestartWorker(ctx context.Context, workspace, teamName, workerName string, opts *WorkerRestartOptions) (*WorkerRestartResult, error) {
 	if opts == nil {
 		opts = &WorkerRestartOptions{
@@ -106,6 +112,10 @@ waitLoop:
 				"team", teamName,
 				"worker", workerName,
 				"grace_period", opts.GracePeriod,
+			)
+			result.Error = fmt.Sprintf(
+				"worker did not acknowledge shutdown within %s; task claims released anyway",
+				opts.GracePeriod,
 			)
 			break waitLoop
 		case <-ticker.C:

--- a/internal/agent/teamcli.go
+++ b/internal/agent/teamcli.go
@@ -252,7 +252,11 @@ func (r *teamCLIRunner) Start(ctx context.Context, issue types.Issue, workspace 
 	initialSnapshot, err := r.waitForTeamReady(startCtx, workspace, teamName)
 	if err != nil {
 		if !errors.Is(err, errTeamMissing) {
-			_ = r.shutdownTeam(context.Background(), workspace, teamName)
+			// Bounded: a hung `team shutdown` here would otherwise block this
+			// Start call (and its caller's dispatch slot) forever.
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			_ = r.shutdownTeam(shutdownCtx, workspace, teamName)
+			shutdownCancel()
 		}
 		return nil, fmt.Errorf("wait for %s team %q readiness: %w", r.name, teamName, err)
 	}

--- a/internal/agent/teamcli.go
+++ b/internal/agent/teamcli.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -233,9 +234,9 @@ func (r *teamCLIRunner) Start(ctx context.Context, issue types.Issue, workspace 
 	startCtx, cancel := context.WithTimeout(ctx, r.startupTimeout)
 	defer cancel()
 
-	output, err := r.runCommand(startCtx, workspace, r.startArgs(r.teamSpec, launchTask)...)
+	stdout, stderr, err := r.runCommand(startCtx, workspace, r.startArgs(r.teamSpec, launchTask)...)
 	if err != nil {
-		return nil, fmt.Errorf("start %s team %q: %w%s", r.name, predictedTeamName, err, formatCommandOutput(output))
+		return nil, fmt.Errorf("start %s team %q: %w%s", r.name, predictedTeamName, err, formatCommandOutput(combineStreams(stdout, stderr)))
 	}
 
 	// omx v0.16+ generates team names with a hash suffix (e.g.
@@ -243,7 +244,7 @@ func (r *teamCLIRunner) Start(ctx context.Context, issue types.Issue, workspace 
 	// on stdout. Parse the actual name so subsequent `team status`/`team await`
 	// calls hit the right team. Fall back to the predicted slug for older
 	// CLIs that did not emit this line.
-	teamName := parseTeamNameFromOutput(output)
+	teamName := parseTeamNameFromOutput(stdout)
 	if teamName == "" {
 		teamName = predictedTeamName
 	}
@@ -612,14 +613,15 @@ func (r *teamCLIRunner) fetchSnapshot(ctx context.Context, workspace, teamName s
 }
 
 func (r *teamCLIRunner) shutdownTeam(ctx context.Context, workspace, teamName string) error {
-	output, err := r.runCommand(ctx, workspace, r.shutdownArgs(teamName)...)
+	stdout, stderr, err := r.runCommand(ctx, workspace, r.shutdownArgs(teamName)...)
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(string(output), "No team state found") {
+	combined := combineStreams(stdout, stderr)
+	if strings.Contains(string(combined), "No team state found") {
 		return nil
 	}
-	return fmt.Errorf("shutdown %s team %q: %w%s", r.name, teamName, err, formatCommandOutput(output))
+	return fmt.Errorf("shutdown %s team %q: %w%s", r.name, teamName, err, formatCommandOutput(combined))
 }
 
 func (r *teamCLIRunner) runTeamAPI(ctx context.Context, workspace, operation string, input interface{}, target interface{}) error {
@@ -628,14 +630,14 @@ func (r *teamCLIRunner) runTeamAPI(ctx context.Context, workspace, operation str
 		return fmt.Errorf("marshal team api input: %w", err)
 	}
 
-	output, err := r.runCommand(ctx, workspace, "team", "api", operation, "--input", string(payload), "--json")
+	stdout, stderr, err := r.runCommand(ctx, workspace, "team", "api", operation, "--input", string(payload), "--json")
 	if err != nil {
-		return fmt.Errorf("run %s team api %s: %w%s", r.name, operation, err, formatCommandOutput(output))
+		return fmt.Errorf("run %s team api %s: %w%s", r.name, operation, err, formatCommandOutput(combineStreams(stdout, stderr)))
 	}
 
 	var envelope teamCLIEnvelope
-	if err := json.Unmarshal(output, &envelope); err != nil {
-		return fmt.Errorf("decode %s team api %s response: %w", r.name, operation, err)
+	if err := json.Unmarshal(stdout, &envelope); err != nil {
+		return fmt.Errorf("decode %s team api %s response: %w%s", r.name, operation, err, formatCommandOutput(stderr))
 	}
 	if envelope.Status == "missing" {
 		return errTeamMissing
@@ -655,15 +657,43 @@ func (r *teamCLIRunner) runTeamAPI(ctx context.Context, workspace, operation str
 	return nil
 }
 
-func (r *teamCLIRunner) runCommand(ctx context.Context, workspace string, args ...string) ([]byte, error) {
+// runCommand executes the team CLI and returns stdout and stderr separately.
+// omx/omc are Node CLIs: runtime warnings (ExperimentalWarning, deprecation
+// notices) land on stderr, and mixing them into stdout corrupts the JSON that
+// runTeamAPI parses — three consecutive decode failures used to shut down a
+// perfectly healthy team.
+func (r *teamCLIRunner) runCommand(ctx context.Context, workspace string, args ...string) (stdout []byte, stderr []byte, err error) {
 	argv := strings.Fields(strings.TrimSpace(r.binaryPath))
 	if len(argv) == 0 {
-		return nil, fmt.Errorf("%s binary path is empty", r.name)
+		return nil, nil, fmt.Errorf("%s binary path is empty", r.name)
 	}
 
 	cmd := exec.CommandContext(ctx, argv[0], append(argv[1:], args...)...)
 	cmd.Dir = workspace
-	return cmd.CombinedOutput()
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.Bytes(), errBuf.Bytes(), err
+}
+
+// combineStreams joins stdout and stderr for human-facing error messages,
+// where seeing both is more useful than stream fidelity.
+func combineStreams(stdout, stderr []byte) []byte {
+	out := bytes.TrimSpace(stdout)
+	errOut := bytes.TrimSpace(stderr)
+	switch {
+	case len(out) == 0:
+		return errOut
+	case len(errOut) == 0:
+		return out
+	default:
+		combined := make([]byte, 0, len(out)+1+len(errOut))
+		combined = append(combined, out...)
+		combined = append(combined, '\n')
+		combined = append(combined, errOut...)
+		return combined
+	}
 }
 
 func isTeamMissingError(err error) bool {

--- a/internal/agent/teamcli_test.go
+++ b/internal/agent/teamcli_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,59 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRunTeamAPI_ToleratesStderrNoise pins the stdout/stderr split: omx/omc
+// are Node CLIs whose runtime warnings (ExperimentalWarning, deprecations)
+// land on stderr. When runCommand returned CombinedOutput, one warning line
+// corrupted the JSON envelope, and three consecutive decode failures in
+// monitorProcess shut down a perfectly healthy team.
+func TestRunTeamAPI_ToleratesStderrNoise(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(t.TempDir(), "noisy-cli.sh")
+	script := `#!/bin/sh
+echo '(node:12345) ExperimentalWarning: fake runtime warning' >&2
+echo '(node:12345) [DEP0040] DeprecationWarning: punycode is deprecated' >&2
+echo '{"ok":true,"operation":"get-summary","data":{"value":42}}'
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	runner := &teamCLIRunner{name: "omx", binaryPath: scriptPath}
+
+	var target struct {
+		Value int `json:"value"`
+	}
+	err := runner.runTeamAPI(context.Background(), t.TempDir(), "get-summary", map[string]string{}, &target)
+	require.NoError(t, err)
+	assert.Equal(t, 42, target.Value)
+}
+
+func TestRunCommand_SplitsStdoutAndStderr(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(t.TempDir(), "split-cli.sh")
+	script := `#!/bin/sh
+echo 'stdout line'
+echo 'stderr line' >&2
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	runner := &teamCLIRunner{name: "omx", binaryPath: scriptPath}
+
+	stdout, stderr, err := runner.runCommand(context.Background(), t.TempDir(), "anything")
+	require.NoError(t, err)
+	assert.Equal(t, "stdout line\n", string(stdout))
+	assert.Equal(t, "stderr line\n", string(stderr))
+}
+
+func TestCombineStreams(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "out", string(combineStreams([]byte("out\n"), nil)))
+	assert.Equal(t, "err", string(combineStreams(nil, []byte("err\n"))))
+	assert.Equal(t, "out\nerr", string(combineStreams([]byte("out\n"), []byte("err\n"))))
+	assert.Empty(t, combineStreams(nil, nil))
+}
 
 func TestParseTeamNameFromOutput(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Part 3/3 of the full-codebase audit fix plan (`.omc/plans/2026-07-16-contrabass-audit-fix-plan.md`). Likely related to the symptoms in #39.

## P0

- **opencode server stdout was never drained after startup.** The startup scanner returned on the "listening on" line; once the server logged ~64KB, its writes blocked on the full pipe and the whole server froze — every session stalled until timeout. The scanner now hands the pipe to `io.Copy(io.Discard)` for the server's lifetime.
- **Team CLI JSON was parsed from `CombinedOutput`.** omx/omc are Node CLIs: one stderr warning (`ExperimentalWarning`, deprecations) corrupted the envelope, and three consecutive decode failures in `monitorProcess` shut down a perfectly healthy team. `runCommand` now captures the streams separately; JSON is parsed from stdout only. The fake omx fixture emits a Node-style stderr warning on every invocation, so the whole team CLI suite pins this.

## P1

- opencode `ensureServer` health-checks cached servers and reaps dead ones instead of reusing a stale URL forever.
- opencode `Start` waits for the SSE subscription to be established before submitting the prompt (early events, including the terminal idle for fast turns, could be missed → hang until timeout).
- codex `Stop` no longer receives from the same `done` channel that delivers the exit error to `AgentProcess.Done` — the loser of that race saw nil from the closed channel, so a failed run could be recorded clean. A separate `exited` signal now serves internal waiters.
- teamcli Start's failure-path shutdown is bounded (30s) instead of `context.Background()` forever; `RestartWorker`'s contract is documented honestly (shutdown + claim release; respawn belongs to the CLI supervisor).

## Tests

`go test ./internal/agent/ ./internal/orchestrator/ ./internal/team/` green. New: `TestOpenCodeRunner_DrainsServerStdoutAfterStartup`, `TestRunTeamAPI_ToleratesStderrNoise`, `TestRunCommand_SplitsStdoutAndStderr`, `TestCombineStreams`.