### PR TITLE
fix(orchestrator): complete stalled/timed-out runs; harden dispatch gating

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,7 +3,9 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -87,6 +89,11 @@ type Orchestrator struct {
 	// most once per orchestrator lifetime.
 	recoveredSet map[string]struct{}
 
+	// warnedCycles tracks BlockedBy cycle signatures already warned about,
+	// so each unique cycle is surfaced at most once per orchestrator
+	// lifetime instead of once per poll tick.
+	warnedCycles map[string]struct{}
+
 	buildInfo BuildInfo
 }
 
@@ -133,6 +140,7 @@ func NewOrchestrator(
 		issueCacheSize:      policy.issueCacheSize,
 		runSignalBufferSize: policy.runSignalBufferSize,
 		recoveredSet:        make(map[string]struct{}),
+		warnedCycles:        make(map[string]struct{}),
 		stats: Stats{
 			MaxAgents: cfg.MaxConcurrency(),
 			StartTime: time.Now(),
@@ -222,7 +230,9 @@ func (o *Orchestrator) runCycle(ctx context.Context, supervisor *errgroup.Group,
 
 	openIDs := buildOpenIDSet(issues)
 
-	o.dispatchReadyBackoff(ctx, supervisorCtxOr(ctx), cfg, issuesByID, supervisor, runSignals)
+	o.clearRequeuedPaused(issues)
+	o.warnBlockedByCycles(issues, openIDs)
+	o.dispatchReadyBackoff(ctx, supervisorCtxOr(ctx), cfg, issuesByID, openIDs, supervisor, runSignals)
 	recoveredAttempts := o.recoverOrphanedClaims(issues)
 	o.dispatchUnclaimedIssues(ctx, supervisorCtxOr(ctx), cfg, issues, openIDs, recoveredAttempts, supervisor, runSignals)
 	o.releaseBlockedRunning(ctx, issuesByID, openIDs)
@@ -254,6 +264,7 @@ func (o *Orchestrator) dispatchReadyBackoff(
 	watchCtx context.Context,
 	cfg *config.WorkflowConfig,
 	issuesByID map[string]types.Issue,
+	openIDs map[string]struct{},
 	supervisor *errgroup.Group,
 	runSignals chan<- runSignal,
 ) {
@@ -290,6 +301,17 @@ func (o *Orchestrator) dispatchReadyBackoff(
 		}
 		if !ok {
 			o.enqueueContinuation(backoffEntry.IssueID, backoffEntry.Attempt, "issue details unavailable")
+			continue
+		}
+
+		// Retries obey the same BlockedBy gate as fresh dispatch; the entry
+		// is requeued with its attempt preserved so retry accounting is not
+		// reset by a blocker that appeared while the issue sat in backoff.
+		if unresolved := unresolvedBlockers(issue.BlockedBy, openIDs); len(unresolved) > 0 {
+			logging.LogIssueEvent(o.logger, issue.ID,
+				"retry_skipped_blocked_by",
+				"blockers", strings.Join(unresolved, ","))
+			o.requeueBackoff(backoffEntry)
 			continue
 		}
 
@@ -414,7 +436,12 @@ func (o *Orchestrator) releaseBlockedRunning(
 			"running_released_blocked_by",
 			"blockers", strings.Join(unresolved, ","))
 
-		o.stopRun(ctx, id)
+		if !o.stopRun(ctx, id) {
+			// Termination unconfirmed: keep the claim so the issue cannot be
+			// re-dispatched onto a workspace the old process may still write.
+			// The blocker is still unresolved next tick, so stop is retried.
+			continue
+		}
 
 		if err := o.tracker.UpdateIssueState(ctx, id, types.Unclaimed); err != nil {
 			logging.LogIssueEvent(o.logger, id,
@@ -443,7 +470,11 @@ func (o *Orchestrator) StopAgent(ctx context.Context, issueID string) error {
 
 	logging.LogIssueEvent(o.logger, issueID, "stop_agent_requested")
 
-	o.stopRun(ctx, issueID)
+	if !o.stopRun(ctx, issueID) {
+		// Keep the claim: releasing it while the process may still be alive
+		// would let the next tick start a second agent in the same workspace.
+		return fmt.Errorf("agent for %s did not exit within the stop grace window; claim retained", issueID)
+	}
 
 	if err := o.tracker.UpdateIssueState(ctx, issueID, types.Released); err != nil {
 		logging.LogIssueEvent(o.logger, issueID, "stop_agent_state_release_failed", "err", err)
@@ -471,6 +502,96 @@ func unresolvedBlockers(blockedBy []string, openIDs map[string]struct{}) []strin
 		}
 	}
 	return unresolved
+}
+
+// detectBlockedByCycles returns the identifier cycles (including
+// self-references) in the BlockedBy graph of the fetched snapshot. Only edges
+// into the open candidate set matter — those are the ones the dispatch gate
+// tests — and each cycle's members are sorted for a stable signature.
+func detectBlockedByCycles(issues []types.Issue, openIDs map[string]struct{}) [][]string {
+	adjacency := make(map[string][]string, len(issues))
+	for _, issue := range issues {
+		if issue.Identifier == "" {
+			continue
+		}
+		for _, blocker := range issue.BlockedBy {
+			if _, open := openIDs[blocker]; open {
+				adjacency[issue.Identifier] = append(adjacency[issue.Identifier], blocker)
+			}
+		}
+	}
+
+	nodes := make([]string, 0, len(adjacency))
+	for node := range adjacency {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	const (
+		unvisited = 0
+		inStack   = 1
+		finished  = 2
+	)
+	state := make(map[string]int, len(adjacency))
+	stack := make([]string, 0, len(adjacency))
+	cycles := make([][]string, 0)
+
+	var visit func(node string)
+	visit = func(node string) {
+		state[node] = inStack
+		stack = append(stack, node)
+		for _, next := range adjacency[node] {
+			switch state[next] {
+			case unvisited:
+				visit(next)
+			case inStack:
+				// Back edge: the cycle is the stack suffix starting at next.
+				start := len(stack) - 1
+				for start > 0 && stack[start] != next {
+					start--
+				}
+				cycle := append([]string(nil), stack[start:]...)
+				sort.Strings(cycle)
+				cycles = append(cycles, cycle)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[node] = finished
+	}
+
+	for _, node := range nodes {
+		if state[node] == unvisited {
+			visit(node)
+		}
+	}
+	return cycles
+}
+
+// warnBlockedByCycles surfaces circular (or self-referencing) BlockedBy
+// dependencies, whose members the dispatch gate would otherwise skip silently
+// forever. Cycle members are deliberately NOT force-dispatched: running work
+// whose declared prerequisites are unsatisfiable risks executing it in the
+// wrong order, so the safer semantic is to keep skipping them and alert a
+// human to fix the dependency data. Each unique cycle is warned once per
+// orchestrator lifetime (tracked via warnedCycles).
+func (o *Orchestrator) warnBlockedByCycles(issues []types.Issue, openIDs map[string]struct{}) {
+	for _, cycle := range detectBlockedByCycles(issues, openIDs) {
+		signature := strings.Join(cycle, ",")
+
+		o.mu.Lock()
+		_, seen := o.warnedCycles[signature]
+		if !seen {
+			o.warnedCycles[signature] = struct{}{}
+		}
+		o.mu.Unlock()
+		if seen {
+			continue
+		}
+
+		o.logger.Warn("blocked_by_cycle_detected",
+			"members", signature,
+			"action", "members stay undispatched until the cycle is broken in the tracker")
+	}
 }
 
 func (o *Orchestrator) dispatchIssue(

--- a/internal/orchestrator/orchestrator_runtime.go
+++ b/internal/orchestrator/orchestrator_runtime.go
@@ -405,6 +405,30 @@ func (o *Orchestrator) pauseUnverifiedSuccess(
 		"status", attempt.Phase.String(), "err", cause)
 }
 
+// clearRequeuedPaused unpauses issues the operator has moved back to an
+// Unclaimed tracker state after a pauseUnverifiedSuccess hold. Without this
+// the paused entry keeps isManagedIssue true forever, so an operator-requeued
+// issue could never be dispatched again until process restart.
+func (o *Orchestrator) clearRequeuedPaused(issues []types.Issue) {
+	for _, issue := range issues {
+		if issue.State != types.Unclaimed {
+			continue
+		}
+
+		o.mu.Lock()
+		_, paused := o.paused[issue.ID]
+		if paused {
+			delete(o.paused, issue.ID)
+		}
+		o.mu.Unlock()
+
+		if paused {
+			logging.LogIssueEvent(o.logger, issue.ID, "paused_cleared_requeued",
+				"identifier", issue.Identifier)
+		}
+	}
+}
+
 func (o *Orchestrator) enqueueContinuation(issueID string, attempt int, message string) {
 	delayMs := o.backoffDelayMs(issueID, 0)
 	retryAt := time.Now().Add(time.Duration(delayMs) * time.Millisecond)
@@ -468,12 +492,24 @@ func (o *Orchestrator) reconcileRunning(ctx context.Context, cfg *config.Workflo
 	now := time.Now()
 	orphaned := make([]string, 0)
 	forceRemoved := make([]string, 0)
+	broken := make([]string, 0)
 
 	o.mu.Lock()
 	for issueID, entry := range o.running {
-		if entry == nil || entry.process == nil || entry.process.Done == nil {
+		if entry == nil {
+			// Placeholder with no run state — nothing to complete.
 			delete(o.running, issueID)
 			forceRemoved = append(forceRemoved, issueID)
+			continue
+		}
+		if entry.process == nil || entry.process.Done == nil {
+			// No watcher exists to deliver a done signal, so completeRun must
+			// be invoked directly (below, after the lock is released) to
+			// release the claim and record the failure.
+			if entry.cancel == nil {
+				entry.cancel = func() {}
+			}
+			broken = append(broken, issueID)
 			continue
 		}
 		if now.Sub(entry.attempt.StartTime) > timeout && isActiveRunPhase(entry.attempt.Phase) {
@@ -492,12 +528,22 @@ func (o *Orchestrator) reconcileRunning(ctx context.Context, cfg *config.Workflo
 			o.logger,
 			"run_force_removed",
 			"issue_id", issueID,
-			"reason", "missing_process_or_done",
+			"reason", "nil_entry",
 		)
 	}
 
+	for _, issueID := range broken {
+		logging.LogOrchestratorEvent(
+			o.logger,
+			"run_force_removed",
+			"issue_id", issueID,
+			"reason", "missing_process_or_done",
+		)
+		o.completeRun(ctx, issueID, errors.New("agent process handle missing done channel"))
+	}
+
 	for _, issueID := range orphaned {
-		o.stopRun(ctx, issueID)
+		o.interruptRun(issueID)
 	}
 }
 
@@ -520,16 +566,44 @@ func (o *Orchestrator) detectStalledRuns(ctx context.Context, cfg *config.Workfl
 	o.mu.Unlock()
 
 	for _, issueID := range stalled {
-		o.stopRun(ctx, issueID)
+		o.interruptRun(issueID)
 	}
 }
 
-func (o *Orchestrator) stopRun(_ context.Context, issueID string) {
+// interruptRun signals the agent process for issueID to terminate but leaves
+// the entry in o.running: the watcher's done signal then drives completeRun
+// on the run loop, which owns claim release, workspace cleanup, the failure
+// record, and retry backoff. Used by the stall/timeout paths, where removing
+// the entry here would make completeRun's not-found guard drop all of that.
+func (o *Orchestrator) interruptRun(issueID string) {
 	o.mu.Lock()
 	entry, ok := o.running[issueID]
 	o.mu.Unlock()
 	if !ok || entry == nil {
 		return
+	}
+
+	entry.cancel()
+	if err := o.agent.Stop(entry.process); err != nil {
+		logging.LogAgentEvent(o.logger, issueID, "stop_failed", "err", err)
+	}
+
+	logging.LogOrchestratorEvent(o.logger, "run_interrupted", "issue_id", issueID)
+}
+
+// stopRun tears down the run for issueID without a completion record — used
+// by explicit stops (operator request, blocker re-validation) where the
+// eventual done signal is intentionally discarded. The entry is removed from
+// o.running only once the process's done signal fires: removing it while the
+// process may still be alive would let the next tick dispatch a second agent
+// into the same workspace. Returns false when termination is unconfirmed;
+// callers must keep the tracker claim and retry on a later tick.
+func (o *Orchestrator) stopRun(_ context.Context, issueID string) bool {
+	o.mu.Lock()
+	entry, ok := o.running[issueID]
+	o.mu.Unlock()
+	if !ok || entry == nil {
+		return true
 	}
 
 	entry.cancel()
@@ -552,6 +626,7 @@ func (o *Orchestrator) stopRun(_ context.Context, issueID string) {
 				"issue_id", issueID,
 				"grace_timeout", graceTimeout.String(),
 			)
+			return false
 		}
 		if !graceTimer.Stop() {
 			select {
@@ -570,6 +645,7 @@ func (o *Orchestrator) stopRun(_ context.Context, issueID string) {
 	o.mu.Unlock()
 
 	logging.LogOrchestratorEvent(o.logger, "run_stopped", "issue_id", issueID, "cleaned_up", true)
+	return true
 }
 
 func (o *Orchestrator) releaseIssue(ctx context.Context, issueID string, from types.IssueState, attempt int) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1195,10 +1195,17 @@ func TestOrchestrator_ReconcileAssignsTimedOut(t *testing.T) {
 	orch.mu.Unlock()
 
 	orch.reconcileRunning(context.Background(), cfg)
-	// reconcileRunning calls stopRun which removes the entry from the map,
-	// but the entry pointer was mutated in-place before removal.
+	// reconcileRunning interrupts the run but must leave the entry in
+	// o.running so the watcher's done signal can drive completeRun (claim
+	// release, workspace cleanup, retry backoff) instead of being dropped by
+	// completeRun's not-found guard.
 	assert.Equal(t, types.TimedOut, entry.attempt.Phase)
 	assert.Equal(t, "run timed out", entry.attempt.Error)
+
+	orch.mu.Lock()
+	_, present := orch.running["ISS-TIMEOUT-1"]
+	orch.mu.Unlock()
+	assert.True(t, present, "timed-out entry must stay managed until its done signal completes the run")
 }
 
 // --- Error Path Tests (T30) ---
@@ -2307,4 +2314,292 @@ func TestSuccessGate_HollowRunReroutesToBackoff(t *testing.T) {
 			require.NoError(t, <-done)
 		})
 	}
+}
+
+// TestStalledRunCompletesWithReleaseAndBackoff is the regression test for the
+// silent stall drop: detectStalledRuns used to call stopRun, which deleted the
+// entry from o.running before the watcher's done signal was drained, so
+// completeRun's not-found guard skipped claim release, workspace cleanup, the
+// failure record, and retry backoff — the issue then hot-looped at attempt 1.
+// The stall must now flow through the same completion path as any failed run.
+func TestStalledRunCompletesWithReleaseAndBackoff(t *testing.T) {
+	issueID := "ISS-STALL"
+	mt := newObservingTracker([]types.Issue{{ID: issueID, Title: "Stall", State: types.Unclaimed}})
+	mw := workspace.NewMockManager(t.TempDir())
+	// One event, then a long silent delay — the run stalls with the process
+	// still alive until the orchestrator interrupts it.
+	mr := &agent.MockRunner{
+		Events: []types.AgentEvent{{Type: "turn/started"}},
+		Delay:  10 * time.Second,
+	}
+
+	workflowCfg := testConfig()
+	workflowCfg.StallTimeoutMsRaw = 50
+	workflowCfg.MaxRetryBackoffMsRaw = 5_000
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: workflowCfg}, nil)
+	events := newEventCollector(orch.Events())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := startOrchestrator(ctx, orch)
+
+	require.Eventually(t, func() bool {
+		phase, ok := events.FinishedPhase(issueID)
+		if !ok || phase != types.Stalled {
+			return false
+		}
+		entries := backoffSnapshot(orch)
+		if len(entries) != 1 || entries[0].IssueID != issueID || entries[0].Attempt != 2 {
+			return false
+		}
+		state, ok := mt.State(issueID)
+		return ok && state == types.RetryQueued &&
+			mt.ReleaseCount(issueID) > 0 &&
+			!mw.Exists(issueID)
+	}, 2*time.Second, 10*time.Millisecond,
+		"stalled run must release the claim, clean the workspace, and enqueue backoff at attempt 2")
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+// --- stopRun grace-timeout unit tests ---
+
+func TestStopRun_GraceTimeoutRetainsEntry(t *testing.T) {
+	mt := newObservingTracker(nil)
+	mw := workspace.NewMockManager(t.TempDir())
+	mr := &agent.MockRunner{}
+	cfg := testConfig()
+	cfg.Orchestrator.StopGraceTimeoutMs = 30
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: cfg}, nil)
+
+	// Process whose done channel never fires and whose PID the runner does
+	// not know — Stop is a no-op, simulating a kill-resistant process.
+	entry := &runEntry{
+		issue:   types.Issue{ID: "ISS-ALIVE", State: types.Running},
+		attempt: types.RunAttempt{IssueID: "ISS-ALIVE", Phase: types.StreamingTurn, Attempt: 1},
+		process: &agent.AgentProcess{PID: 4242, SessionID: "alive", Done: make(chan error)},
+		cancel:  func() {},
+	}
+	orch.mu.Lock()
+	orch.running["ISS-ALIVE"] = entry
+	orch.stats.Running = 1
+	orch.mu.Unlock()
+
+	stopped := orch.stopRun(context.Background(), "ISS-ALIVE")
+
+	assert.False(t, stopped, "unconfirmed termination must be reported to the caller")
+	orch.mu.Lock()
+	_, present := orch.running["ISS-ALIVE"]
+	orch.mu.Unlock()
+	assert.True(t, present,
+		"entry must be retained while the process may still be alive, so the issue cannot be re-dispatched")
+}
+
+func TestStopAgent_GraceTimeoutKeepsClaim(t *testing.T) {
+	target := types.Issue{ID: "ISS-A", Identifier: "ISS-A", State: types.Running}
+	mt := newObservingTracker([]types.Issue{target})
+	mw := workspace.NewMockManager(t.TempDir())
+	mr := &agent.MockRunner{}
+	cfg := testConfig()
+	cfg.Orchestrator.StopGraceTimeoutMs = 30
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: cfg}, nil)
+
+	orch.mu.Lock()
+	orch.running["ISS-A"] = &runEntry{
+		issue:   target,
+		attempt: types.RunAttempt{IssueID: "ISS-A", Phase: types.StreamingTurn, Attempt: 1},
+		process: &agent.AgentProcess{PID: 4243, SessionID: "alive", Done: make(chan error)},
+		cancel:  func() {},
+	}
+	orch.stats.Running = 1
+	orch.mu.Unlock()
+
+	err := orch.StopAgent(context.Background(), "ISS-A")
+
+	require.Error(t, err, "StopAgent must not report success while the process may still be alive")
+	assert.Zero(t, mt.ReleaseCount("ISS-A"), "claim must be kept until termination is confirmed")
+	assert.Zero(t, mt.UpdateIssueStateCount("ISS-A", types.Released))
+	orch.mu.Lock()
+	_, present := orch.running["ISS-A"]
+	orch.mu.Unlock()
+	assert.True(t, present)
+}
+
+// --- dispatchReadyBackoff blocker gating ---
+
+func TestDispatchReadyBackoff_GatesOnBlockedBy(t *testing.T) {
+	// The blocker was created while ISS-X sat in backoff. The retry must obey
+	// the same BlockedBy gate as fresh dispatch and keep its attempt count.
+	retryIssue := types.Issue{
+		ID: "ISS-X", Identifier: "ZII-50", Title: "Retry", State: types.RetryQueued,
+		BlockedBy: []string{"ZII-49"},
+	}
+	blocker := types.Issue{ID: "ISS-B", Identifier: "ZII-49", Title: "Blocker", State: types.Running}
+	mt := newObservingTracker([]types.Issue{retryIssue, blocker})
+	mw := workspace.NewMockManager(t.TempDir())
+	mr := &agent.MockRunner{
+		Events: []types.AgentEvent{},
+		Delay:  10 * time.Second,
+	}
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: testConfig()}, nil)
+	go func() {
+		for range orch.Events() {
+		}
+	}()
+
+	orch.mu.Lock()
+	orch.backoff = []types.BackoffEntry{{
+		IssueID: "ISS-X",
+		Attempt: 3,
+		RetryAt: time.Now().Add(-time.Second), // already ready
+	}}
+	orch.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := startOrchestrator(ctx, orch)
+
+	// Allow several poll cycles (poll interval is 10ms in testConfig), then
+	// stop the loop so the backoff slice is not observed mid-drain.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+
+	require.Equal(t, 0, mt.ClaimCount("ISS-X"),
+		"ready backoff entry must not dispatch while its blocker is in the candidate set")
+
+	entries := backoffSnapshot(orch)
+	require.Len(t, entries, 1, "blocked retry must be requeued, not consumed")
+	assert.Equal(t, "ISS-X", entries[0].IssueID)
+	assert.Equal(t, 3, entries[0].Attempt, "requeue must preserve the attempt counter")
+}
+
+// --- BlockedBy cycle detection ---
+
+func TestDetectBlockedByCycles(t *testing.T) {
+	cases := []struct {
+		name   string
+		issues []types.Issue
+		want   [][]string
+	}{
+		{
+			name: "no cycle in a linear chain",
+			issues: []types.Issue{
+				{ID: "1", Identifier: "A", BlockedBy: []string{"B"}},
+				{ID: "2", Identifier: "B"},
+			},
+			want: [][]string{},
+		},
+		{
+			name: "blocker outside the open set is ignored",
+			issues: []types.Issue{
+				{ID: "1", Identifier: "A", BlockedBy: []string{"GONE"}},
+			},
+			want: [][]string{},
+		},
+		{
+			name: "self reference",
+			issues: []types.Issue{
+				{ID: "1", Identifier: "A", BlockedBy: []string{"A"}},
+			},
+			want: [][]string{{"A"}},
+		},
+		{
+			name: "mutual blockers",
+			issues: []types.Issue{
+				{ID: "1", Identifier: "A", BlockedBy: []string{"B"}},
+				{ID: "2", Identifier: "B", BlockedBy: []string{"A"}},
+			},
+			want: [][]string{{"A", "B"}},
+		},
+		{
+			name: "cycle reached through a chain",
+			issues: []types.Issue{
+				{ID: "1", Identifier: "A", BlockedBy: []string{"B"}},
+				{ID: "2", Identifier: "B", BlockedBy: []string{"C"}},
+				{ID: "3", Identifier: "C", BlockedBy: []string{"B"}},
+			},
+			want: [][]string{{"B", "C"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectBlockedByCycles(tc.issues, buildOpenIDSet(tc.issues))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBlockedByCycle_SkippedAndWarnedOnce(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewWithOptions(&buf, log.Options{Level: log.WarnLevel})
+
+	mt := newObservingTracker([]types.Issue{
+		{ID: "ISS-A", Identifier: "ZII-A", Title: "A", State: types.Unclaimed, BlockedBy: []string{"ZII-B"}},
+		{ID: "ISS-B", Identifier: "ZII-B", Title: "B", State: types.Unclaimed, BlockedBy: []string{"ZII-A"}},
+	})
+	mw := workspace.NewMockManager(t.TempDir())
+	mr := &agent.MockRunner{}
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: testConfig()}, logger)
+	go func() {
+		for range orch.Events() {
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := startOrchestrator(ctx, orch)
+
+	// Allow several poll cycles so the once-per-cycle dedup is exercised.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+
+	assert.Equal(t, 0, mt.ClaimCount("ISS-A"), "cycle members must stay undispatched")
+	assert.Equal(t, 0, mt.ClaimCount("ISS-B"), "cycle members must stay undispatched")
+	assert.Equal(t, 1, strings.Count(buf.String(), "blocked_by_cycle_detected"),
+		"each unique cycle must be warned exactly once, not once per tick")
+	assert.Contains(t, buf.String(), "ZII-A,ZII-B")
+}
+
+// --- paused map cleanup ---
+
+func TestPausedIssueRequeuedByOperatorRedispatches(t *testing.T) {
+	issue := types.Issue{ID: "ISS-P", Identifier: "ISS-P", Title: "Paused", State: types.Unclaimed}
+	mt := newObservingTracker([]types.Issue{issue})
+	mw := workspace.NewMockManager(t.TempDir())
+	mr := &agent.MockRunner{
+		Events: []types.AgentEvent{{Type: "turn/completed"}},
+		Delay:  10 * time.Millisecond,
+	}
+	orch := NewOrchestrator(mt, mw, mr, &staticConfig{cfg: testConfig()}, nil)
+	go func() {
+		for range orch.Events() {
+		}
+	}()
+
+	// Simulate a prior pauseUnverifiedSuccess hold; the tracker snapshot
+	// already shows the issue back in Unclaimed (operator re-queued it).
+	orch.mu.Lock()
+	orch.paused["ISS-P"] = "success_unverified_branch_unchanged"
+	orch.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := startOrchestrator(ctx, orch)
+
+	require.Eventually(t, func() bool {
+		return mt.ClaimCount("ISS-P") > 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"operator-requeued issue must be dispatched again once the pause is cleared")
+
+	orch.mu.Lock()
+	_, stillPaused := orch.paused["ISS-P"]
+	orch.mu.Unlock()
+	assert.False(t, stillPaused, "paused entry must be removed when the tracker shows Unclaimed")
+
+	cancel()
+	require.NoError(t, <-done)
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -309,6 +309,14 @@ func classifyAgentStageWithPolicy(
 	var stage string
 	var step int
 
+	// A zero LastDiffChange means this is the first classification for the
+	// run: anchor the plateau clock at now, otherwise elapsed is measured
+	// from the zero time, a fresh run classifies as Reviewing (step 4), and
+	// the monotonic clamp locks it there for the whole run.
+	if state.LastDiffChange.IsZero() {
+		state.LastDiffChange = now
+	}
+
 	switch lastActivityKind {
 	case "turn/completed", "turn/failed", "turn/cancelled":
 		stage, step = "Wrapping", 5

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -506,3 +506,22 @@ func TestSnapshot_ReleasesAgentStageState(t *testing.T) {
 	assert.Len(t, snap2.Running, 0)
 	assert.Equal(t, 0, len(o.running))
 }
+
+func TestClassifyAgentStage_ZeroLastDiffChangeStartsAtExploration(t *testing.T) {
+	baseTime := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// Zero value, exactly as on a freshly-created runEntry: without the
+	// first-tick anchor, elapsed would be measured from the zero time and the
+	// run would classify as Reviewing (4) with the clamp locking it there.
+	state := &agentStageState{}
+
+	stage, step := classifyAgentStage(state, "tool_call", 0, 0, 0, baseTime)
+	assert.Equal(t, "Exploration", stage)
+	assert.Equal(t, 1, step)
+	assert.Equal(t, baseTime, state.LastDiffChange, "plateau clock must anchor at the first tick")
+
+	// The clamp must not have locked the run: a growing diff on the next
+	// tick advances to Editing.
+	stage2, step2 := classifyAgentStage(state, "tool_call", 10, 2, 80_000, baseTime.Add(5*time.Second))
+	assert.Equal(t, "Editing", stage2)
+	assert.Equal(t, 2, step2)
+}


### PR DESCRIPTION
Wave 2/1 of the audit fix plan (`.omc/plans/2026-07-16-contrabass-audit-fix-plan.md`, resumed-audit HIGH + 5 mediums).

**HIGH — stalled/timed-out runs never reached completeRun**: stopRun deleted the entry from `o.running` before the watcher's done signal arrived (same-goroutine ordering), so completeRun's not-found guard silently dropped claim release, workspace cleanup, the failure record, and retry backoff — a permanently-stalling agent hot-looped forever at attempt 1. New `interruptRun` cancels the run but leaves the entry, letting the watcher drive completeRun's normal failure path; broken handles (nil process/Done) invoke completeRun directly.

Also: BlockedBy cycle detection (once-per-cycle warn, members stay undispatched), dispatchReadyBackoff now honors BlockedBy, paused entries clear when the tracker shows Unclaimed again, stopRun keeps the entry on grace-timeout (no second agent into a live workspace), classifyAgentStage anchors zero LastDiffChange (fresh runs no longer clamp-lock at Reviewing).

Adversarial review: approved, 0 blocking. Rebased onto post-#46 main (recovered-attempt handling combined with the new gating). `go test ./internal/orchestrator/...` green.