### PR TITLE
fix(tmux,team): exit-code marker completion detection; stop re-executing stale team state

### DIFF
--- a/internal/agent/tmux_integration_test.go
+++ b/internal/agent/tmux_integration_test.go
@@ -82,7 +82,7 @@ func TestTmuxRunner_IntegrationPipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			workspace := t.TempDir()
 			stateDir := t.TempDir()
-			mockRunner := newIntegrationMockRunner(workspace, tt.processCount)
+			mockRunner := newIntegrationMockRunner(tt.processCount)
 
 			teamName := "team-integration"
 			paths := team.NewPaths(stateDir)
@@ -141,6 +141,12 @@ func TestTmuxRunner_IntegrationPipeline(t *testing.T) {
 				}
 				for _, hb := range heartbeats {
 					if hb.Status != "running" {
+						return false
+					}
+					// Runner heartbeats must stay out of the coordinator's
+					// "worker-<n>" namespace so they cannot mask a genuinely
+					// stale coordinator worker.
+					if !strings.HasPrefix(hb.WorkerID, "tmux-worker-") {
 						return false
 					}
 				}
@@ -205,7 +211,7 @@ func TestTmuxRunner_IntegrationPipeline(t *testing.T) {
 	}
 }
 
-func newIntegrationMockRunner(workspace string, processCount int) *integrationMockRunner {
+func newIntegrationMockRunner(processCount int) *integrationMockRunner {
 	handlers := map[string]func(args []string) ([]byte, error){
 		"tmux list-panes -t %1 -F #{pane_dead}": func(_ []string) ([]byte, error) {
 			return []byte("0\n"), nil
@@ -215,25 +221,13 @@ func newIntegrationMockRunner(workspace string, processCount int) *integrationMo
 		},
 	}
 
-	handlers["tmux new-window -t contrabass-team-integration -n worker-1 -P -F #{pane_id}"] = func(_ []string) ([]byte, error) {
+	handlers["tmux new-window -t =contrabass-team-integration -n tmux-worker-1 -P -F #{pane_id}"] = func(_ []string) ([]byte, error) {
 		return []byte("%1\n"), nil
-	}
-	handlers["tmux send-keys -t %1 cd "+shellQuoteForIntegrationKey(workspace)+" C-m"] = func(_ []string) ([]byte, error) {
-		return nil, nil
-	}
-	handlers["tmux send-keys -t %1 codex app-server C-m"] = func(_ []string) ([]byte, error) {
-		return nil, nil
 	}
 
 	if processCount > 1 {
-		handlers["tmux new-window -t contrabass-team-integration -n worker-2 -P -F #{pane_id}"] = func(_ []string) ([]byte, error) {
+		handlers["tmux new-window -t =contrabass-team-integration -n tmux-worker-2 -P -F #{pane_id}"] = func(_ []string) ([]byte, error) {
 			return []byte("%2\n"), nil
-		}
-		handlers["tmux send-keys -t %2 cd "+shellQuoteForIntegrationKey(workspace)+" C-m"] = func(_ []string) ([]byte, error) {
-			return nil, nil
-		}
-		handlers["tmux send-keys -t %2 codex app-server C-m"] = func(_ []string) ([]byte, error) {
-			return nil, nil
 		}
 		handlers["tmux list-panes -t %2 -F #{pane_dead}"] = func(_ []string) ([]byte, error) {
 			return []byte("0\n"), nil
@@ -244,12 +238,4 @@ func newIntegrationMockRunner(workspace string, processCount int) *integrationMo
 	}
 
 	return &integrationMockRunner{handlers: handlers}
-}
-
-func shellQuoteForIntegrationKey(value string) string {
-	if value == "" {
-		return "''"
-	}
-
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/internal/agent/tmux_runner.go
+++ b/internal/agent/tmux_runner.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,10 +62,11 @@ type tmuxProcess struct {
 	taskID    string
 	workspace string
 
-	promptPath string
-	events     chan types.AgentEvent
-	done       chan error
-	finished   chan struct{}
+	promptPath     string
+	exitMarkerPath string
+	events         chan types.AgentEvent
+	done           chan error
+	finished       chan struct{}
 
 	cancel     context.CancelFunc
 	finishOnce sync.Once
@@ -140,17 +144,28 @@ func (r *TmuxRunner) Start(ctx context.Context, issue types.Issue, workspace str
 	}
 
 	pid := int(r.pidSeq.Add(1))
-	workerID := fmt.Sprintf("worker-%d", pid)
+	// The "tmux-" prefix keeps these synthetic IDs out of the coordinator's
+	// "worker-<n>" heartbeat namespace, where a collision would keep a dead
+	// coordinator worker's heartbeat fresh and mask its staleness.
+	workerID := fmt.Sprintf("tmux-worker-%d", pid)
 	taskID := firstNonEmpty(issue.ID, issue.Identifier, workerID)
 	cliArgs := cliCfg.BuildArgs(workspace, promptPath)
 
+	exitMarkerPath, err := prepareExitMarker(workspace, pid)
+	if err != nil {
+		return nil, fmt.Errorf("prepare exit marker: %w", err)
+	}
+
 	bootstrap := tmux.NewWorkerBootstrap(r.session, tmux.BootstrapConfig{
-		WorkerID:   workerID,
-		TeamName:   r.teamName,
-		WorkDir:    workspace,
-		CLICommand: binaryPath,
-		CLIArgs:    cliArgs,
-		Env:        cliCfg.Env,
+		WorkerID:       workerID,
+		TeamName:       r.teamName,
+		WorkDir:        workspace,
+		CLICommand:     binaryPath,
+		CLIArgs:        cliArgs,
+		Env:            cliCfg.Env,
+		PromptMode:     cliCfg.PromptMode,
+		PromptPath:     promptPath,
+		ExitMarkerPath: exitMarkerPath,
 	})
 
 	paneID, err := bootstrap.Bootstrap(ctx)
@@ -159,15 +174,16 @@ func (r *TmuxRunner) Start(ctx context.Context, issue types.Issue, workspace str
 	}
 
 	state := &tmuxProcess{
-		pid:        pid,
-		paneID:     paneID,
-		workerID:   workerID,
-		taskID:     taskID,
-		workspace:  workspace,
-		promptPath: promptPath,
-		events:     make(chan types.AgentEvent, 128),
-		done:       make(chan error, 1),
-		finished:   make(chan struct{}),
+		pid:            pid,
+		paneID:         paneID,
+		workerID:       workerID,
+		taskID:         taskID,
+		workspace:      workspace,
+		promptPath:     promptPath,
+		exitMarkerPath: exitMarkerPath,
+		events:         make(chan types.AgentEvent, 128),
+		done:           make(chan error, 1),
+		finished:       make(chan struct{}),
 	}
 
 	if r.dispatchQueue != nil {
@@ -273,14 +289,43 @@ func (r *TmuxRunner) monitorProcess(ctx context.Context, bootstrap *tmux.WorkerB
 		}
 	}
 
+	// Completion comes from the exit marker the pane's shell writes when the
+	// CLI command exits — never from pane liveness. The interactive shell
+	// keeps the pane alive after the command exits, and a pane that dies
+	// without a marker (tmux destroys dead panes, so IsWorkerAlive errors)
+	// means the command was killed, not that it finished.
 	checkAlive := func(logStarted bool) (bool, error) {
-		alive, err := bootstrap.IsWorkerAlive(ctx, proc.paneID)
+		exitCode, exited, markerErr := readExitMarker(proc.exitMarkerPath)
+
+		paneAlive := true
+		var paneErr error
+		if !exited && markerErr == nil {
+			paneAlive, paneErr = bootstrap.IsWorkerAlive(ctx, proc.paneID)
+			if paneErr != nil || !paneAlive {
+				// The command may have exited and written the marker just
+				// before the pane closed; re-check before calling it a crash.
+				exitCode, exited, markerErr = readExitMarker(proc.exitMarkerPath)
+			}
+		}
+
+		var failure error
+		switch {
+		case markerErr != nil:
+			failure = fmt.Errorf("read exit marker for pane %s: %w", proc.paneID, markerErr)
+		case exited && exitCode != 0:
+			failure = fmt.Errorf("worker command exited with code %d", exitCode)
+		case !exited && paneErr != nil:
+			failure = fmt.Errorf("worker pane %s died before writing exit marker: %w", proc.paneID, paneErr)
+		case !exited && !paneAlive:
+			failure = fmt.Errorf("worker pane %s died before writing exit marker", proc.paneID)
+		}
+
 		now := time.Now()
 
 		status := "running"
-		if err != nil {
+		if failure != nil {
 			status = "error"
-		} else if !alive {
+		} else if exited {
 			status = "stopped"
 		}
 
@@ -316,16 +361,16 @@ func (r *TmuxRunner) monitorProcess(ctx context.Context, bootstrap *tmux.WorkerB
 			}
 		}
 
-		if err != nil {
-			return false, err
+		if failure != nil {
+			return false, failure
 		}
-		if !alive {
+		if exited {
 			if r.eventLogger != nil {
 				if logErr := r.eventLogger.Log(r.teamName, ipc.Event{
 					Type:      "worker_stopped",
 					WorkerID:  proc.workerID,
 					TaskID:    proc.taskID,
-					Data:      map[string]interface{}{"pane_id": proc.paneID},
+					Data:      map[string]interface{}{"pane_id": proc.paneID, "exit_code": exitCode},
 					Timestamp: now,
 				}); logErr != nil {
 					r.logger.Warn("tmux worker_stopped log failed", "team", r.teamName, "worker_id", proc.workerID, "error", logErr)
@@ -366,6 +411,7 @@ func (r *TmuxRunner) monitorProcess(ctx context.Context, bootstrap *tmux.WorkerB
 			"worker_id": proc.workerID,
 			"task_id":   proc.taskID,
 		})
+		r.cleanupPane(proc)
 		proc.finish(nil)
 		return
 	}
@@ -395,9 +441,60 @@ func (r *TmuxRunner) monitorProcess(ctx context.Context, bootstrap *tmux.WorkerB
 					"worker_id": proc.workerID,
 					"task_id":   proc.taskID,
 				})
+				r.cleanupPane(proc)
 				proc.finish(nil)
 				return
 			}
 		}
 	}
+}
+
+// cleanupPane kills the pane after a successful completion: the CLI ran
+// inside the pane's interactive shell, so the pane stays alive after the
+// command exits. Failed panes are intentionally kept for post-mortem.
+func (r *TmuxRunner) cleanupPane(proc *tmuxProcess) {
+	killCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := r.session.KillPane(killCtx, proc.paneID); err != nil {
+		r.logger.Warn("tmux pane cleanup failed", "team", r.teamName, "pane_id", proc.paneID, "error", err)
+	}
+}
+
+// prepareExitMarker returns the file the pane shell writes the CLI's exit
+// code to. A stale marker left by a previous run of the same workspace is
+// removed first so an old exit code cannot complete the new task instantly.
+func prepareExitMarker(workspace string, pid int) (string, error) {
+	dir := filepath.Join(workspace, ".contrabass")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, fmt.Sprintf("task-exit-%d", pid))
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	return path, nil
+}
+
+// readExitMarker reports the exit code recorded by the pane shell. found is
+// false while the command is still running, or while the marker write is
+// mid-flight and the file is momentarily empty.
+func readExitMarker(path string) (code int, found bool, err error) {
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return 0, false, nil
+		}
+		return 0, false, readErr
+	}
+
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return 0, false, nil
+	}
+
+	code, parseErr := strconv.Atoi(content)
+	if parseErr != nil {
+		return 0, false, fmt.Errorf("parse exit marker %s: %w", path, parseErr)
+	}
+	return code, true, nil
 }

--- a/internal/agent/tmux_runner_test.go
+++ b/internal/agent/tmux_runner_test.go
@@ -3,8 +3,11 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -23,11 +26,8 @@ func TestTmuxRunner_CompileTimeCheck(t *testing.T) {
 func TestTmuxRunner_StartCreatesProcess(t *testing.T) {
 	workspace := t.TempDir()
 	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
-		"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
-		"tmux send-keys -t %1 cd " + shellQuoteForKey(workspace) + " C-m": {},
-		"tmux send-keys -t %1 codex app-server C-m":                       {},
-		"tmux list-panes -t %1 -F #{pane_dead}":                           {output: []byte("0\n")},
-		"tmux kill-pane -t %1":                                            {},
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("0\n")},
 	})
 
 	proc, err := runner.Start(context.Background(), types.Issue{ID: "CB-1", Title: "tmux"}, workspace, "run this")
@@ -48,11 +48,9 @@ func TestTmuxRunner_StopKillsPaneAndSignalsDone(t *testing.T) {
 	workspace := t.TempDir()
 	killErr := errors.New("kill failed")
 	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
-		"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
-		"tmux send-keys -t %1 cd " + shellQuoteForKey(workspace) + " C-m": {},
-		"tmux send-keys -t %1 codex app-server C-m":                       {},
-		"tmux list-panes -t %1 -F #{pane_dead}":                           {output: []byte("0\n")},
-		"tmux kill-pane -t %1":                                            {err: killErr},
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("0\n")},
+		"tmux kill-pane -t %1":                                                  {err: killErr},
 	})
 
 	proc, err := runner.Start(context.Background(), types.Issue{ID: "CB-2"}, workspace, "run this")
@@ -74,16 +72,10 @@ func TestTmuxRunner_StopKillsPaneAndSignalsDone(t *testing.T) {
 func TestTmuxRunner_CloseStopsAllProcesses(t *testing.T) {
 	workspace := t.TempDir()
 	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
-		"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
-		"tmux send-keys -t %1 cd " + shellQuoteForKey(workspace) + " C-m": {},
-		"tmux send-keys -t %1 codex app-server C-m":                       {},
-		"tmux list-panes -t %1 -F #{pane_dead}":                           {output: []byte("0\n")},
-		"tmux kill-pane -t %1":                                            {},
-		"tmux new-window -t contrabass-team -n worker-2 -P -F #{pane_id}": {output: []byte("%2\n")},
-		"tmux send-keys -t %2 cd " + shellQuoteForKey(workspace) + " C-m": {},
-		"tmux send-keys -t %2 codex app-server C-m":                       {},
-		"tmux list-panes -t %2 -F #{pane_dead}":                           {output: []byte("0\n")},
-		"tmux kill-pane -t %2":                                            {},
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("0\n")},
+		"tmux new-window -t =contrabass-team -n tmux-worker-2 -P -F #{pane_id}": {output: []byte("%2\n")},
+		"tmux list-panes -t %2 -F #{pane_dead}":                                 {output: []byte("0\n")},
 	})
 
 	proc1, err := runner.Start(context.Background(), types.Issue{ID: "CB-3"}, workspace, "run one")
@@ -96,23 +88,65 @@ func TestTmuxRunner_CloseStopsAllProcesses(t *testing.T) {
 	assertDoneNil(t, proc2.Done)
 }
 
-func TestTmuxRunner_MonitorDetectsDeadPane(t *testing.T) {
+// Completion must come from the CLI command's exit marker, not from pane
+// liveness: the CLI runs inside the pane's interactive shell, so the pane
+// outlives the command and #{pane_dead} never fires on normal exit.
+func TestTmuxRunner_ExitMarkerCompletesTask(t *testing.T) {
 	workspace := t.TempDir()
 	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
-		"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
-		"tmux send-keys -t %1 cd " + shellQuoteForKey(workspace) + " C-m": {},
-		"tmux send-keys -t %1 codex app-server C-m":                       {},
-		"tmux list-panes -t %1 -F #{pane_dead}":                           {output: []byte("1\n")},
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("0\n")},
 	})
 
 	proc, err := runner.Start(context.Background(), types.Issue{ID: "CB-5"}, workspace, "run this")
 	require.NoError(t, err)
+
+	writeExitMarker(t, workspace, 1, "0\n")
 
 	events := collectOpenCodeEvents(t, proc.Events, proc.Done, 2, 2*time.Second)
 	require.Len(t, events, 2)
 	assert.Equal(t, "turn/started", events[0].Type)
 	assert.Equal(t, "task/completed", events[1].Type)
 	assertDoneNil(t, proc.Done)
+}
+
+func TestTmuxRunner_ExitMarkerNonZeroFailsTask(t *testing.T) {
+	workspace := t.TempDir()
+	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("0\n")},
+	})
+
+	proc, err := runner.Start(context.Background(), types.Issue{ID: "CB-5b"}, workspace, "run this")
+	require.NoError(t, err)
+
+	writeExitMarker(t, workspace, 1, "3\n")
+
+	events := collectOpenCodeEvents(t, proc.Events, proc.Done, 2, 2*time.Second)
+	require.Len(t, events, 2)
+	assert.Equal(t, "turn/started", events[0].Type)
+	assert.Equal(t, "turn/failed", events[1].Type)
+	assertDoneErrContains(t, proc.Done, "exited with code 3")
+}
+
+// A dead pane without an exit marker is a crash, not a completion: tmux only
+// reports pane_dead=1 when the pane's root shell died, which cannot happen on
+// a normal CLI exit under this bootstrap.
+func TestTmuxRunner_DeadPaneWithoutMarkerFailsTask(t *testing.T) {
+	workspace := t.TempDir()
+	runner := setupTmuxRunner(t, workspace, tmuxMockSpecs{
+		"tmux new-window -t =contrabass-team -n tmux-worker-1 -P -F #{pane_id}": {output: []byte("%1\n")},
+		"tmux list-panes -t %1 -F #{pane_dead}":                                 {output: []byte("1\n")},
+	})
+
+	proc, err := runner.Start(context.Background(), types.Issue{ID: "CB-5c"}, workspace, "run this")
+	require.NoError(t, err)
+
+	events := collectOpenCodeEvents(t, proc.Events, proc.Done, 2, 2*time.Second)
+	require.Len(t, events, 2)
+	assert.Equal(t, "turn/started", events[0].Type)
+	assert.Equal(t, "turn/failed", events[1].Type)
+	assertDoneErrContains(t, proc.Done, "died before writing exit marker")
 }
 
 func TestTmuxRunner_StartUnknownAgentType(t *testing.T) {
@@ -178,10 +212,24 @@ func (m *mockTmuxRunner) Run(_ context.Context, name string, args ...string) ([]
 	return result.output, result.err
 }
 
-func shellQuoteForKey(value string) string {
-	if value == "" {
-		return "''"
-	}
+// writeExitMarker simulates the pane shell recording the CLI's exit code
+// (see prepareExitMarker for the path layout).
+func writeExitMarker(t *testing.T, workspace string, pid int, content string) {
+	t.Helper()
 
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+	dir := filepath.Join(workspace, ".contrabass")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("task-exit-%d", pid)), []byte(content), 0o644))
+}
+
+func assertDoneErrContains(t *testing.T, done <-chan error, substr string) {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), substr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected done channel to be signaled")
+	}
 }

--- a/internal/team/coordinator.go
+++ b/internal/team/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -128,8 +129,26 @@ func (c *Coordinator) Mailbox() *Mailbox { return c.mailbox }
 // Ownership returns the ownership registry.
 func (c *Coordinator) Ownership() *OwnershipRegistry { return c.ownership }
 
-// Initialize creates the team manifest and directory structure.
+// Initialize creates the team manifest and directory structure. State left
+// by a finished (terminal) run of the same team name is wiped first so its
+// leftover task files cannot be claimed alongside the new run's tasks; a
+// non-terminal team is refused because a live coordinator may still own it.
 func (c *Coordinator) Initialize(teamCfg types.TeamConfig) error {
+	if c.store.TeamExists(c.teamName) {
+		state, err := c.store.LoadPhaseState(c.teamName)
+		switch {
+		case err == nil && !state.Phase.IsTerminal():
+			return fmt.Errorf("team %q already exists in phase %q; wait for it to finish or remove its state dir %s",
+				c.teamName, state.Phase, c.paths.TeamDir(c.teamName))
+		case err != nil && !errors.Is(err, os.ErrNotExist):
+			return fmt.Errorf("team %q already exists but its phase state is unreadable; remove its state dir %s manually: %w",
+				c.teamName, c.paths.TeamDir(c.teamName), err)
+		}
+		if err := c.store.DeleteTeam(c.teamName); err != nil {
+			return fmt.Errorf("clear previous team state: %w", err)
+		}
+	}
+
 	if _, err := c.store.CreateManifest(c.teamName, teamCfg); err != nil {
 		return fmt.Errorf("create team manifest: %w", err)
 	}
@@ -593,6 +612,18 @@ func (c *Coordinator) checkTransitionGovernance(ctx context.Context, phase types
 		return err
 	}
 
+	if !allTerminal {
+		// Pending tasks whose dependency chain contains a failed task can
+		// only progress after the fix loop resets that dependency. Treating
+		// them as settled lets exec/verify hand off to the fix loop instead
+		// of tripping PhaseGateRule and hard-failing the pipeline.
+		settled, settledErr := c.allTasksSettled()
+		if settledErr != nil {
+			return settledErr
+		}
+		allTerminal = settled
+	}
+
 	_, activeWorkerCount := c.workerGovernanceSnapshot("")
 
 	return c.governance.Check(ctx, Decision{
@@ -602,6 +633,62 @@ func (c *Coordinator) checkTransitionGovernance(ctx context.Context, phase types
 		ActiveWorkerCount:         activeWorkerCount,
 		CurrentPhaseTasksTerminal: allTerminal,
 	})
+}
+
+// allTasksSettled reports whether every task is terminal or is a pending
+// task blocked (transitively) by a failed dependency. Such pending tasks are
+// unclaimable until the fix loop resets the failed task, so they must not
+// keep the phase gate closed.
+func (c *Coordinator) allTasksSettled() (bool, error) {
+	tasks, err := c.tasks.ListTasks(c.teamName)
+	if err != nil {
+		return false, err
+	}
+
+	byID := make(map[string]*types.TeamTask, len(tasks))
+	for i := range tasks {
+		byID[tasks[i].ID] = &tasks[i]
+	}
+
+	var blockedByFailed func(id string, seen map[string]bool) bool
+	blockedByFailed = func(id string, seen map[string]bool) bool {
+		if seen[id] {
+			return false
+		}
+		seen[id] = true
+		task := byID[id]
+		if task == nil {
+			return false
+		}
+		for _, depID := range task.DependsOn {
+			dep := byID[depID]
+			if dep == nil {
+				continue
+			}
+			if dep.Status == types.TaskFailed {
+				return true
+			}
+			if dep.Status == types.TaskPending && blockedByFailed(depID, seen) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i := range tasks {
+		switch tasks[i].Status {
+		case types.TaskCompleted, types.TaskFailed:
+			continue
+		case types.TaskPending:
+			if !blockedByFailed(tasks[i].ID, make(map[string]bool)) {
+				return false, nil
+			}
+		default:
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func (c *Coordinator) executeTask(ctx context.Context, task *types.TeamTask, token string, workerID string) error {
@@ -764,7 +851,12 @@ func (c *Coordinator) heartbeatLoop(ctx context.Context, workerID string, pid in
 func (c *Coordinator) checkForStaleWorkers() []string {
 	c.mu.Lock()
 	workerIDs := make([]string, 0, len(c.workers))
-	for id := range c.workers {
+	for id, w := range c.workers {
+		// Idle workers stop heartbeating by design once their task ends;
+		// a frozen heartbeat file is only meaningful mid-task.
+		if w.state.CurrentTask == "" {
+			continue
+		}
 		workerIDs = append(workerIDs, id)
 	}
 	c.mu.Unlock()

--- a/internal/team/coordinator_test.go
+++ b/internal/team/coordinator_test.go
@@ -132,6 +132,175 @@ func TestRunFixPhaseResetsFailedTasks(t *testing.T) {
 	assert.Equal(t, types.PhaseExec, phase)
 }
 
+func TestInitializeRefusesActiveTeam(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		Agent: config.AgentConfig{Type: "codex"},
+		Team: config.TeamSectionConfig{
+			MaxWorkers:        1,
+			MaxFixLoops:       2,
+			ClaimLeaseSeconds: 300,
+			StateDir:          t.TempDir(),
+		},
+	}
+
+	coordinator := NewCoordinator(
+		"test-team",
+		cfg,
+		nil,
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	teamCfg := types.TeamConfig{MaxWorkers: 1, MaxFixLoops: 2}
+	require.NoError(t, coordinator.Initialize(teamCfg))
+
+	// The team sits in a non-terminal phase (plan); a second run of the same
+	// name must not reset the phase machine underneath it.
+	err := coordinator.Initialize(teamCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	phase, err := coordinator.phases.CurrentPhase("test-team")
+	require.NoError(t, err)
+	assert.Equal(t, types.PhasePlan, phase)
+}
+
+func TestInitializeWipesTerminalTeamState(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		Agent: config.AgentConfig{Type: "codex"},
+		Team: config.TeamSectionConfig{
+			MaxWorkers:        1,
+			MaxFixLoops:       2,
+			ClaimLeaseSeconds: 300,
+			StateDir:          t.TempDir(),
+		},
+	}
+
+	coordinator := NewCoordinator(
+		"test-team",
+		cfg,
+		nil,
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	teamCfg := types.TeamConfig{MaxWorkers: 1, MaxFixLoops: 2}
+	require.NoError(t, coordinator.Initialize(teamCfg))
+	require.NoError(t, coordinator.tasks.CreateTask("test-team", &types.TeamTask{ID: "stale-task", Subject: "old run"}))
+
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhasePRD, "plan complete"))
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhaseExec, "prd complete"))
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhaseVerify, "exec complete"))
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhaseComplete, "verified"))
+
+	// Re-running the same team name must not leave the previous run's task
+	// files claimable next to the new run's tasks.
+	require.NoError(t, coordinator.Initialize(teamCfg))
+
+	tasks, err := coordinator.tasks.ListTasks("test-team")
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+
+	phase, err := coordinator.phases.CurrentPhase("test-team")
+	require.NoError(t, err)
+	assert.Equal(t, types.PhasePlan, phase)
+}
+
+func TestExecPhaseRoutesBlockedOnFailedTasksToFixLoop(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		Agent: config.AgentConfig{Type: "codex"},
+		Team: config.TeamSectionConfig{
+			MaxWorkers:        1,
+			MaxFixLoops:       2,
+			ClaimLeaseSeconds: 300,
+			StateDir:          t.TempDir(),
+		},
+	}
+
+	coordinator := NewCoordinator(
+		"test-team",
+		cfg,
+		nil,
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	require.NoError(t, coordinator.Initialize(types.TeamConfig{MaxWorkers: 1, MaxFixLoops: 2}))
+	require.NoError(t, coordinator.tasks.CreateTask("test-team", &types.TeamTask{ID: "task-a", Subject: "upstream"}))
+	require.NoError(t, coordinator.tasks.CreateTask("test-team", &types.TeamTask{
+		ID:        "task-b",
+		Subject:   "downstream",
+		DependsOn: []string{"task-a"},
+	}))
+
+	token, err := coordinator.tasks.ClaimTask("test-team", "task-a", "worker-0", 1)
+	require.NoError(t, err)
+	require.NoError(t, coordinator.tasks.FailTask("test-team", "task-a", token, "boom"))
+
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhasePRD, "plan complete"))
+	require.NoError(t, coordinator.phases.Transition("test-team", types.PhaseExec, "prd complete"))
+
+	// task-b is pending but unclaimable (its dependency failed); exec must
+	// hand off toward the fix loop instead of tripping the phase gate.
+	require.NoError(t, coordinator.runExecPhase(context.Background()))
+
+	phase, err := coordinator.phases.CurrentPhase("test-team")
+	require.NoError(t, err)
+	require.Equal(t, types.PhaseVerify, phase)
+
+	require.NoError(t, coordinator.runVerifyPhase(context.Background()))
+	phase, err = coordinator.phases.CurrentPhase("test-team")
+	require.NoError(t, err)
+	require.Equal(t, types.PhaseFix, phase)
+
+	require.NoError(t, coordinator.runFixPhase(context.Background()))
+	phase, err = coordinator.phases.CurrentPhase("test-team")
+	require.NoError(t, err)
+	require.Equal(t, types.PhaseExec, phase)
+
+	resetTask, err := coordinator.tasks.GetTask("test-team", "task-a")
+	require.NoError(t, err)
+	assert.Equal(t, types.TaskPending, resetTask.Status)
+}
+
+func TestCheckForStaleWorkersSkipsIdleWorkers(t *testing.T) {
+	cfg := &config.WorkflowConfig{
+		Agent: config.AgentConfig{Type: "codex"},
+		Team: config.TeamSectionConfig{
+			MaxWorkers:        2,
+			MaxFixLoops:       2,
+			ClaimLeaseSeconds: 1,
+			StateDir:          t.TempDir(),
+		},
+	}
+
+	coordinator := NewCoordinator(
+		"test-team",
+		cfg,
+		nil,
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	require.NoError(t, coordinator.Initialize(types.TeamConfig{MaxWorkers: 2, MaxFixLoops: 2}))
+
+	old := time.Now().Add(-5 * time.Second)
+	for _, workerID := range []string{"worker-0", "worker-1"} {
+		require.NoError(t, coordinator.heartbeats.Write("test-team", Heartbeat{WorkerID: workerID, Timestamp: time.Now()}))
+		path := coordinator.paths.HeartbeatPath("test-team", workerID)
+		require.NoError(t, os.Chtimes(path, old, old))
+	}
+
+	coordinator.mu.Lock()
+	// worker-0 finished its task: heartbeatLoop stopped by design, so its
+	// frozen heartbeat file must not be reported as stale.
+	coordinator.workers["worker-0"] = &workerHandle{state: types.WorkerState{ID: "worker-0", Status: "idle"}}
+	coordinator.workers["worker-1"] = &workerHandle{state: types.WorkerState{ID: "worker-1", Status: "working", CurrentTask: "task-1"}}
+	coordinator.mu.Unlock()
+
+	stale := coordinator.checkForStaleWorkers()
+	assert.Equal(t, []string{"worker-1"}, stale)
+}
+
 func TestCoordinatorRunStartupRecoveryCleansStaleHeartbeat(t *testing.T) {
 	cfg := &config.WorkflowConfig{
 		Agent: config.AgentConfig{Type: "codex"},

--- a/internal/team/integration_test.go
+++ b/internal/team/integration_test.go
@@ -1,6 +1,8 @@
 package team
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -72,6 +74,58 @@ func TestStoreLifecycle(t *testing.T) {
 
 	// Verify team no longer exists
 	assert.False(t, store.TeamExists("test-team"))
+}
+
+// TestCreateManifestRefusesExistingTeam ensures a second CreateManifest for
+// the same team name cannot reset the phase machine and manifest underneath
+// an existing run.
+func TestCreateManifestRefusesExistingTeam(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	_, err := store.CreateManifest("test-team", types.TeamConfig{MaxWorkers: 1})
+	require.NoError(t, err)
+
+	_, err = store.CreateManifest("test-team", types.TeamConfig{MaxWorkers: 2})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTeamExists)
+
+	// The original manifest must be untouched.
+	manifest, err := store.LoadManifest("test-team")
+	require.NoError(t, err)
+	assert.Equal(t, 1, manifest.Config.MaxWorkers)
+}
+
+// TestListTasksSkipsCorruptButSurfacesUnreadableFiles pins the error
+// classification in ListTasks: corrupt JSON is skipped (matching the other
+// registries), but I/O failures must not silently shrink the task board.
+func TestListTasksSkipsCorruptButSurfacesUnreadableFiles(t *testing.T) {
+	store, paths := setupTestStore(t)
+	registry := NewTaskRegistry(store, paths, 300)
+
+	_, err := store.CreateManifest("test-team", types.TeamConfig{MaxWorkers: 1})
+	require.NoError(t, err)
+	require.NoError(t, registry.CreateTask("test-team", &types.TeamTask{ID: "task-1", Subject: "ok"}))
+
+	corrupt := filepath.Join(paths.TasksDir("test-team"), "task-2.json")
+	require.NoError(t, os.WriteFile(corrupt, []byte("{not json"), 0o644))
+
+	tasks, err := registry.ListTasks("test-team")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "task-1", tasks[0].ID)
+
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based unreadable files cannot be simulated as root")
+	}
+
+	unreadable := filepath.Join(paths.TasksDir("test-team"), "task-3.json")
+	require.NoError(t, os.WriteFile(unreadable, []byte("{}"), 0o644))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+	_, err = registry.ListTasks("test-team")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task-3.json")
 }
 
 // TestPhaseTransitions tests valid phase transitions through the pipeline.

--- a/internal/team/rotation.go
+++ b/internal/team/rotation.go
@@ -181,7 +181,9 @@ func (r *StaleLockRecovery) RecoverStaleLocks(teamName string) error {
 			errs = append(errs, fmt.Errorf("walk team dir: %w", walkErr))
 			return nil
 		}
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".tmp") {
+		// Store temp files are named "<path>.tmp.<pid>.<unixnano>" (see
+		// writeJSONBytesNoLock), so match the ".tmp." infix, not a suffix.
+		if d.IsDir() || !strings.Contains(d.Name(), ".tmp.") {
 			return nil
 		}
 

--- a/internal/team/rotation_test.go
+++ b/internal/team/rotation_test.go
@@ -160,8 +160,10 @@ func TestStaleLockRecovery_RecoverStaleLocks(t *testing.T) {
 				teamDir := paths.TeamDir(teamName)
 				require.NoError(t, os.MkdirAll(filepath.Join(teamDir, "tasks"), 0o755))
 
-				staleTmp := filepath.Join(teamDir, "manifest.json.tmp")
-				recentTmp := filepath.Join(teamDir, "tasks", "task-1.json.tmp")
+				// Names must match the Store's real temp scheme
+				// "<path>.tmp.<pid>.<unixnano>" (writeJSONBytesNoLock).
+				staleTmp := filepath.Join(teamDir, "manifest.json.tmp.4242.1712000000000000000")
+				recentTmp := filepath.Join(teamDir, "tasks", "task-1.json.tmp.4242.1712000000000000001")
 				nonTmp := filepath.Join(teamDir, "phase-state.json")
 
 				require.NoError(t, os.WriteFile(staleTmp, []byte("stale"), 0o644))
@@ -176,10 +178,10 @@ func TestStaleLockRecovery_RecoverStaleLocks(t *testing.T) {
 			assertion: func(t *testing.T, paths *Paths, teamName string) {
 				t.Helper()
 				teamDir := paths.TeamDir(teamName)
-				_, staleErr := os.Stat(filepath.Join(teamDir, "manifest.json.tmp"))
+				_, staleErr := os.Stat(filepath.Join(teamDir, "manifest.json.tmp.4242.1712000000000000000"))
 				assert.True(t, os.IsNotExist(staleErr))
 
-				_, recentErr := os.Stat(filepath.Join(teamDir, "tasks", "task-1.json.tmp"))
+				_, recentErr := os.Stat(filepath.Join(teamDir, "tasks", "task-1.json.tmp.4242.1712000000000000001"))
 				require.NoError(t, recentErr)
 
 				_, nonTmpErr := os.Stat(filepath.Join(teamDir, "phase-state.json"))

--- a/internal/team/store.go
+++ b/internal/team/store.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/junhoyeo/contrabass/internal/types"
 )
+
+// ErrTeamExists is returned by CreateManifest when the team already has a
+// manifest on disk. Overwriting would reset the phase machine underneath a
+// live coordinator and leave the previous run's task files claimable.
+var ErrTeamExists = errors.New("team already exists")
 
 // Store provides atomic filesystem operations for team state.
 type Store struct {
@@ -94,10 +100,16 @@ func (s *Store) ReadJSON(path string, v interface{}) error {
 	return nil
 }
 
-// CreateManifest initializes a new team with its manifest and directory structure.
+// CreateManifest initializes a new team with its manifest and directory
+// structure. It refuses to overwrite an existing team (ErrTeamExists);
+// callers must delete the previous team's state first.
 func (s *Store) CreateManifest(teamName string, cfg types.TeamConfig) (*types.TeamManifest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if _, err := os.Stat(s.paths.ManifestPath(teamName)); err == nil {
+		return nil, fmt.Errorf("%w: %s", ErrTeamExists, teamName)
+	}
 
 	if err := s.EnsureDirs(teamName); err != nil {
 		return nil, fmt.Errorf("ensure dirs: %w", err)

--- a/internal/team/tasks.go
+++ b/internal/team/tasks.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,7 +102,19 @@ func (r *TaskRegistry) ListTasks(teamName string) ([]types.TeamTask, error) {
 		var task types.TeamTask
 		path := filepath.Join(dir, entry.Name())
 		if err := r.store.ReadJSON(path, &task); err != nil {
-			continue
+			// A task deleted between ReadDir and read is a benign race, and
+			// corrupt JSON is skipped like other registries do. Any other
+			// read failure (permissions, transient EMFILE) must surface:
+			// silently dropping a task lets AllTasksCompleted report the
+			// pipeline done without ever executing it.
+			if os.IsNotExist(err) {
+				continue
+			}
+			if isJSONUnmarshalError(err) {
+				slog.Default().Warn("skipping malformed task file", "team", teamName, "path", path, "error", err)
+				continue
+			}
+			return nil, fmt.Errorf("read task file %s: %w", entry.Name(), err)
 		}
 
 		if r.applyLeaseExpiry(&task) {

--- a/internal/tmux/bootstrap.go
+++ b/internal/tmux/bootstrap.go
@@ -22,6 +22,15 @@ type BootstrapConfig struct {
 	CLIArgs         []string
 	BootstrapPrompt string
 	Env             map[string]string
+	// PromptMode and PromptPath deliver the task prompt to the CLI: "stdin"
+	// and "file" modes redirect the prompt file into the command's stdin.
+	PromptMode string
+	PromptPath string
+	// ExitMarkerPath, when set, appends a shell wrapper that writes the CLI
+	// command's exit code to this file when it exits. The CLI runs as a
+	// child of the pane's interactive shell, so the pane stays alive after
+	// the command exits — #{pane_dead} can never signal completion.
+	ExitMarkerPath string
 }
 
 type WorkerBootstrap struct {
@@ -75,6 +84,17 @@ func (w *WorkerBootstrap) Bootstrap(ctx context.Context) (paneID string, err err
 		cliParts = append(cliParts, shellQuote(arg))
 	}
 	fullCLICmd := strings.Join(cliParts, " ")
+
+	if promptPath := strings.TrimSpace(w.config.PromptPath); promptPath != "" {
+		switch w.config.PromptMode {
+		case promptModeStdin, promptModeFile:
+			fullCLICmd += " < " + shellQuote(promptPath)
+		}
+	}
+
+	if marker := strings.TrimSpace(w.config.ExitMarkerPath); marker != "" {
+		fullCLICmd += "; echo $? > " + shellQuote(marker)
+	}
 
 	if err := w.session.SendKeys(ctx, createdPaneID, fullCLICmd, "C-m"); err != nil {
 		return "", fmt.Errorf("launch worker %q cli command: %w", w.config.WorkerID, err)

--- a/internal/tmux/bootstrap_test.go
+++ b/internal/tmux/bootstrap_test.go
@@ -13,7 +13,7 @@ import (
 func TestWorkerBootstrapBootstrap(t *testing.T) {
 	runner := &MockRunner{
 		results: map[string]mockResult{
-			"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%3\n")},
+			"tmux new-window -t =contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%3\n")},
 		},
 	}
 
@@ -41,13 +41,43 @@ func TestWorkerBootstrapBootstrap(t *testing.T) {
 	}
 
 	expected := [][]string{
-		{"new-window", "-t", "contrabass-team", "-n", "worker-1", "-P", "-F", "#{pane_id}"},
+		{"new-window", "-t", "=contrabass-team", "-n", "worker-1", "-P", "-F", "#{pane_id}"},
 		{"send-keys", "-t", "%3", "export API_TOKEN='a b'", "C-m"},
 		{"send-keys", "-t", "%3", "export ZED='value'", "C-m"},
 		{"send-keys", "-t", "%3", "cd '/tmp/work dir'", "C-m"},
 		{"send-keys", "-t", "%3", "'contrabass' 'team' '2:executor'", "C-m"},
 	}
 	assert.Equal(t, expected, got)
+}
+
+func TestWorkerBootstrapBootstrapWrapsPromptAndExitMarker(t *testing.T) {
+	runner := &MockRunner{
+		results: map[string]mockResult{
+			"tmux new-window -t =contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%4\n")},
+		},
+	}
+
+	b := NewWorkerBootstrap(NewSession("team", runner), BootstrapConfig{
+		WorkerID:       "worker-1",
+		TeamName:       "team",
+		WorkDir:        "/tmp/work",
+		CLICommand:     "opencode",
+		CLIArgs:        []string{"run"},
+		PromptMode:     promptModeFile,
+		PromptPath:     "/tmp/work/prompt task.md",
+		ExitMarkerPath: "/tmp/work/.contrabass/task-exit-1",
+	})
+	b.startupDelay = time.Millisecond
+
+	_, err := b.Bootstrap(context.Background())
+	require.NoError(t, err)
+
+	last := runner.calls[len(runner.calls)-1]
+	assert.Equal(t, []string{
+		"send-keys", "-t", "%4",
+		"'opencode' 'run' < '/tmp/work/prompt task.md'; echo $? > '/tmp/work/.contrabass/task-exit-1'",
+		"C-m",
+	}, last.args)
 }
 
 func TestWorkerBootstrapBootstrapValidationErrors(t *testing.T) {
@@ -106,8 +136,8 @@ func TestWorkerBootstrapBootstrapValidationErrors(t *testing.T) {
 func TestWorkerBootstrapBootstrapCleansUpOnFailure(t *testing.T) {
 	runner := &MockRunner{
 		results: map[string]mockResult{
-			"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%7")},
-			"tmux send-keys -t %7 cd '/tmp/work' C-m":                         {err: errors.New("send failed")},
+			"tmux new-window -t =contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%7")},
+			"tmux send-keys -t %7 cd '/tmp/work' C-m":                          {err: errors.New("send failed")},
 		},
 	}
 

--- a/internal/tmux/cli_registry.go
+++ b/internal/tmux/cli_registry.go
@@ -28,23 +28,29 @@ type CLIRegistry struct {
 func NewCLIRegistry() *CLIRegistry {
 	r := &CLIRegistry{configs: make(map[string]CLIConfig, 5)}
 
-	// Codex starts an app-server subprocess and receives prompts over stdin JSONL.
+	// Pane-based completion detection requires run-to-completion commands:
+	// the bootstrap redirects the prompt file into stdin and records the
+	// command's exit code in a marker file. Server entrypoints ("codex
+	// app-server", "opencode serve") never exit, so a tmux worker driving
+	// them would hang forever.
+
+	// Codex runs a one-shot non-interactive turn; "-" reads the prompt from stdin.
 	mustRegister(r, CLIConfig{
 		AgentType:  "codex",
 		BinaryPath: "codex",
 		BuildArgs: func(_, _ string) []string {
-			return []string{"app-server"}
+			return []string{"exec", "-"}
 		},
 		PromptMode:   promptModeStdin,
 		ReadyPattern: "initialized",
 	})
 
-	// OpenCode starts an HTTP/SSE server and consumes prompt content from a file.
+	// OpenCode runs a single prompt to completion, reading it from piped stdin.
 	mustRegister(r, CLIConfig{
 		AgentType:  "opencode",
 		BinaryPath: "opencode",
 		BuildArgs: func(_, _ string) []string {
-			return []string{"serve"}
+			return []string{"run"}
 		},
 		PromptMode:   promptModeFile,
 		ReadyPattern: "serve|listening",
@@ -72,12 +78,13 @@ func NewCLIRegistry() *CLIRegistry {
 		ReadyPattern: "team",
 	})
 
-	// oh-my-opencode wraps OpenCode and commonly receives prompt content from file.
+	// oh-my-opencode wraps OpenCode's CLI surface; "run" executes a single
+	// piped prompt to completion instead of launching the interactive TUI.
 	mustRegister(r, CLIConfig{
 		AgentType:  "oh-my-opencode",
 		BinaryPath: "oh-my-opencode",
 		BuildArgs: func(_, _ string) []string {
-			return []string{}
+			return []string{"run"}
 		},
 		PromptMode:   promptModeFile,
 		ReadyPattern: "ready|serve|listening",

--- a/internal/tmux/cli_registry_test.go
+++ b/internal/tmux/cli_registry_test.go
@@ -28,11 +28,11 @@ func TestCLIRegistry_Get(t *testing.T) {
 		promptMode string
 		wantArgs   []string
 	}{
-		{name: "codex", agentType: "codex", binaryPath: "codex", promptMode: "stdin", wantArgs: []string{"app-server"}},
-		{name: "opencode", agentType: "opencode", binaryPath: "opencode", promptMode: "file", wantArgs: []string{"serve"}},
+		{name: "codex", agentType: "codex", binaryPath: "codex", promptMode: "stdin", wantArgs: []string{"exec", "-"}},
+		{name: "opencode", agentType: "opencode", binaryPath: "opencode", promptMode: "file", wantArgs: []string{"run"}},
 		{name: "omx", agentType: "omx", binaryPath: "omx", promptMode: "arg", wantArgs: []string{"team"}},
 		{name: "omc", agentType: "omc", binaryPath: "omc", promptMode: "arg", wantArgs: []string{"team"}},
-		{name: "oh-my-opencode", agentType: "oh-my-opencode", binaryPath: "oh-my-opencode", promptMode: "file", wantArgs: []string{}},
+		{name: "oh-my-opencode", agentType: "oh-my-opencode", binaryPath: "oh-my-opencode", promptMode: "file", wantArgs: []string{"run"}},
 	}
 
 	r := NewCLIRegistry()
@@ -130,11 +130,14 @@ func TestCLIRegistry_BuildArgsForEachAgentType(t *testing.T) {
 		agentType string
 		want      []string
 	}{
-		{name: "codex app-server", agentType: "codex", want: []string{"app-server"}},
-		{name: "opencode serve", agentType: "opencode", want: []string{"serve"}},
+		// Every entry must be a run-to-completion command: pane-based workers
+		// detect completion from the command's exit, so a server entrypoint
+		// (e.g. "opencode serve") would hang the pipeline forever.
+		{name: "codex exec", agentType: "codex", want: []string{"exec", "-"}},
+		{name: "opencode run", agentType: "opencode", want: []string{"run"}},
 		{name: "omx team", agentType: "omx", want: []string{"team"}},
 		{name: "omc team", agentType: "omc", want: []string{"team"}},
-		{name: "oh-my-opencode default", agentType: "oh-my-opencode", want: []string{}},
+		{name: "oh-my-opencode run", agentType: "oh-my-opencode", want: []string{"run"}},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -98,7 +98,7 @@ func (s *Session) Kill(ctx context.Context) error {
 		return fmt.Errorf("session name is empty")
 	}
 
-	if _, err := s.runTmux(ctx, "kill-session", "-t", s.Name); err != nil {
+	if _, err := s.runTmux(ctx, "kill-session", "-t", s.exactTarget()); err != nil {
 		return fmt.Errorf("kill tmux session %q: %w", s.Name, err)
 	}
 
@@ -111,8 +111,15 @@ func (s *Session) IsAlive(ctx context.Context) bool {
 		return false
 	}
 
-	_, err := s.runTmux(ctx, "has-session", "-t", s.Name)
+	_, err := s.runTmux(ctx, "has-session", "-t", s.exactTarget())
 	return err == nil
+}
+
+// exactTarget returns the session name with tmux's "=" exact-match prefix.
+// Without it tmux falls back to prefix matching, so operations on team
+// "alpha" could target team "alpha-2"'s session.
+func (s *Session) exactTarget() string {
+	return "=" + s.Name
 }
 
 // ListPanes returns all panes for this session.
@@ -121,7 +128,7 @@ func (s *Session) ListPanes(ctx context.Context) ([]PaneInfo, error) {
 		return nil, fmt.Errorf("session is nil")
 	}
 
-	output, err := s.runTmux(ctx, "list-panes", "-t", s.Name, "-F", paneListFormat)
+	output, err := s.runTmux(ctx, "list-panes", "-t", s.exactTarget(), "-F", paneListFormat)
 	if err != nil {
 		return nil, fmt.Errorf("list panes for session %q: %w", s.Name, err)
 	}
@@ -198,7 +205,7 @@ func (s *Session) NewWindow(ctx context.Context, windowName string) (string, err
 		return "", fmt.Errorf("window name is empty")
 	}
 
-	output, err := s.runTmux(ctx, "new-window", "-t", s.Name, "-n", windowName, "-P", "-F", "#{pane_id}")
+	output, err := s.runTmux(ctx, "new-window", "-t", s.exactTarget(), "-n", windowName, "-P", "-F", "#{pane_id}")
 	if err != nil {
 		return "", fmt.Errorf("create tmux window %q: %w", windowName, err)
 	}

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -54,7 +54,7 @@ func TestSessionCreate(t *testing.T) {
 		{
 			name: "creates session when absent",
 			results: map[string]mockResult{
-				"tmux has-session -t contrabass-team": {err: errors.New("exit status 1")},
+				"tmux has-session -t =contrabass-team": {err: errors.New("exit status 1")},
 			},
 			assertErr: func(t *testing.T, err error) {
 				require.NoError(t, err)
@@ -65,19 +65,19 @@ func TestSessionCreate(t *testing.T) {
 		{
 			name: "returns already exists error",
 			results: map[string]mockResult{
-				"tmux has-session -t contrabass-team": {},
+				"tmux has-session -t =contrabass-team": {},
 			},
 			assertErr: func(t *testing.T, err error) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "already exists")
 			},
 			callCount: 1,
-			lastCall:  []string{"has-session", "-t", "contrabass-team"},
+			lastCall:  []string{"has-session", "-t", "=contrabass-team"},
 		},
 		{
 			name: "returns clear error when tmux is missing",
 			results: map[string]mockResult{
-				"tmux has-session -t contrabass-team": {err: errors.New("exit status 1")},
+				"tmux has-session -t =contrabass-team": {err: errors.New("exit status 1")},
 				"tmux new-session -d -s contrabass-team": {
 					err: &exec.Error{Name: "tmux", Err: exec.ErrNotFound},
 				},
@@ -109,7 +109,7 @@ func TestSessionCreate(t *testing.T) {
 func TestSessionListPanes(t *testing.T) {
 	runner := &MockRunner{
 		results: map[string]mockResult{
-			"tmux list-panes -t contrabass-team -F " + paneListFormat: {
+			"tmux list-panes -t =contrabass-team -F " + paneListFormat: {
 				output: []byte("%0:0:1:0:4242:bash\n%1:1:0:1:5252:worker"),
 			},
 		},
@@ -143,7 +143,7 @@ func TestSessionSplitPane(t *testing.T) {
 func TestSessionNewWindow(t *testing.T) {
 	runner := &MockRunner{
 		results: map[string]mockResult{
-			"tmux new-window -t contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%3")},
+			"tmux new-window -t =contrabass-team -n worker-1 -P -F #{pane_id}": {output: []byte("%3")},
 		},
 	}
 
@@ -151,6 +151,25 @@ func TestSessionNewWindow(t *testing.T) {
 	paneID, err := session.NewWindow(context.Background(), "worker-1")
 	require.NoError(t, err)
 	assert.Equal(t, "%3", paneID)
+}
+
+// Session-level targets must use tmux's "=" exact-match prefix; a bare name
+// prefix-matches other sessions (contrabass-team vs contrabass-team-2), so
+// Kill/IsAlive could hit another team.
+func TestSessionTargetsUseExactMatch(t *testing.T) {
+	runner := &MockRunner{
+		results: map[string]mockResult{
+			"tmux has-session -t =contrabass-team": {},
+		},
+	}
+	session := NewSession("team", runner)
+
+	assert.True(t, session.IsAlive(context.Background()))
+	require.NoError(t, session.Kill(context.Background()))
+
+	require.Len(t, runner.calls, 2)
+	assert.Equal(t, []string{"has-session", "-t", "=contrabass-team"}, runner.calls[0].args)
+	assert.Equal(t, []string{"kill-session", "-t", "=contrabass-team"}, runner.calls[1].args)
 }
 
 func TestSessionSendKeys(t *testing.T) {


### PR DESCRIPTION
Wave 2/2 — closes the root cause of #39.

**HIGH — completion was equated with tmux pane death**, which never happens: the CLI runs inside an interactive shell (pane survives CLI exit), and server-mode registry entries (`opencode serve`) never exit at all. The bootstrap now wraps the CLI so its exit code lands in `<workspace>/.contrabass/task-exit-<id>`; the monitor polls the marker first (0 = complete, non-zero = failed) and treats pane death without a marker — including IsPaneDead erroring because the pane is gone — as a crash, never success. Server-mode registry entries switched to run-to-completion commands (`opencode run`, `codex exec -`, `oh-my-opencode run`).

**HIGH — CreateManifest overwrote existing team manifest/phase state** and leftover task files were re-executed: Store now refuses with ErrTeamExists; Coordinator.Initialize wipes only terminal previous runs and refuses live teams.

Also: exact-match tmux session targeting (`=name`, no more alpha/alpha-2 collisions), namespaced tmux worker heartbeat IDs, blocked-on-failed tasks route to the fix loop instead of hard-failing the pipeline, ListTasks surfaces I/O errors, idle workers no longer flagged stale, stale-lock recovery matches real temp-file names.

Adversarial review: approved, 0 blocking. `go test ./internal/team/... ./internal/tmux/... ./internal/agent/...` green after rebase.