### PR TITLE
fix(web): replace wildcard CORS with origin/Host validation; wire board SSE events

### DIFF
--- a/cmd/contrabass/main.go
+++ b/cmd/contrabass/main.go
@@ -330,6 +330,9 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 		}
 
 		srv := web.NewServer(fmt.Sprintf("localhost:%d", port), orch, h, dashboardFS)
+		// Board mutations made over HTTP must flow back into the hub so other
+		// dashboard tabs and stream subscribers see them live.
+		srv.SetEventSink(webEvents)
 		srv.SetAgentStopper(orch)
 		if boardProvider, ok := trackerClient.(web.BoardProvider); ok {
 			srv.SetBoardProvider(boardProvider)

--- a/cmd/contrabass/main.go
+++ b/cmd/contrabass/main.go
@@ -314,12 +314,7 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 		h = hub.NewHub(webEvents)
 		go h.Run(ctx)
 
-		go func() {
-			for orchEvent := range orch.Events() {
-				webEvents <- web.NewOrchestratorWebEvent(orchEvent)
-			}
-			close(webEvents)
-		}()
+		go forwardOrchestratorEvents(orch.Events(), webEvents)
 
 		var dashboardFS fs.FS
 		if _, statErr := fs.Stat(contrabass.DashboardDistFS, "packages/dashboard/dist"); statErr == nil {
@@ -359,6 +354,18 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 		return runHeadless(ctx, orch, logger, h)
 	}
 	return runTUI(ctx, orch, h)
+}
+
+// forwardOrchestratorEvents copies orchestrator events into the hub source
+// channel. It must NOT close webEvents: HTTP handlers publish board mutations
+// into the same channel (Server.SetEventSink), and in-flight requests can
+// outlive the orchestrator during the server's graceful shutdown window —
+// closing here would make publishEvent panic with send on closed channel.
+// The hub shuts down via ctx instead.
+func forwardOrchestratorEvents(orchEvents <-chan orchestrator.OrchestratorEvent, webEvents chan<- web.WebEvent) {
+	for orchEvent := range orchEvents {
+		webEvents <- web.NewOrchestratorWebEvent(orchEvent)
+	}
 }
 
 // runDryRun starts the orchestrator and exits after the first emitted event.

--- a/cmd/contrabass/main_test.go
+++ b/cmd/contrabass/main_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/junhoyeo/contrabass/internal/config"
 	"github.com/junhoyeo/contrabass/internal/orchestrator"
 	"github.com/junhoyeo/contrabass/internal/types"
+	"github.com/junhoyeo/contrabass/internal/web"
 )
 
 func TestRootCommandHelp(t *testing.T) {
@@ -583,4 +584,36 @@ func TestRunTUI_TUIErrorOrchestratorSuccess(t *testing.T) {
 	err := runTUI(context.Background(), orch, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, tuiErr)
+}
+
+// Regression: the forwarder used to close webEvents after the orchestrator's
+// event channel drained. HTTP handlers publish into the same channel via
+// Server.SetEventSink, so an in-flight board request during the server's
+// graceful-shutdown window would panic with send on closed channel.
+func TestForwardOrchestratorEventsLeavesSinkOpen(t *testing.T) {
+	orchEvents := make(chan orchestrator.OrchestratorEvent, 1)
+	webEvents := make(chan web.WebEvent, 2)
+
+	orchEvents <- orchestrator.OrchestratorEvent{Type: orchestrator.EventStatusUpdate}
+	close(orchEvents)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		forwardOrchestratorEvents(orchEvents, webEvents)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("forwarder did not return after source channel closed")
+	}
+
+	forwarded := <-webEvents
+	assert.Equal(t, orchestrator.EventStatusUpdate.String(), forwarded.Type)
+
+	// A handler publish after the orchestrator is gone must not panic: the
+	// sink stays open and the hub tears down via ctx instead.
+	webEvents <- web.WebEvent{Type: "board"}
+	assert.Len(t, webEvents, 1)
 }

--- a/cmd/contrabass/team_root.go
+++ b/cmd/contrabass/team_root.go
@@ -104,6 +104,7 @@ func runTeamExecutionWebServer(ctx context.Context, logger *log.Logger, port int
 
 	provider := web.NewTeamSnapshotProvider()
 	srv := web.NewServer(fmt.Sprintf("localhost:%d", port), provider, h, dashboardFS)
+	srv.SetEventSink(webEvents)
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -12,6 +12,9 @@ type Hub[T any] struct {
 	subscribers map[int]chan T
 	nextID      int
 	source      <-chan T
+	// closed is set when Run exits; the hub never restarts, so late
+	// subscribers must not be handed a channel nothing will ever write to.
+	closed bool
 }
 
 func NewHub[T any](source <-chan T) *Hub[T] {
@@ -29,9 +32,24 @@ func (h *Hub[T]) Subscribe() (int, <-chan T) {
 	h.nextID++
 
 	ch := make(chan T, defaultSubscriberBufferSize)
+	if h.closed {
+		// Run has exited: return an already-closed channel instead of
+		// registering a subscriber that would silently never receive.
+		close(ch)
+		return id, ch
+	}
 	h.subscribers[id] = ch
 
 	return id, ch
+}
+
+// Closed reports whether Run has exited; a closed hub delivers no further
+// events and Subscribe returns pre-closed channels.
+func (h *Hub[T]) Closed() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.closed
 }
 
 func (h *Hub[T]) Unsubscribe(id int) {
@@ -84,6 +102,7 @@ func (h *Hub[T]) Run(ctx context.Context) {
 }
 
 func (h *Hub[T]) closeAllSubscribersLocked() {
+	h.closed = true
 	for id, sub := range h.subscribers {
 		close(sub)
 		delete(h.subscribers, id)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -160,6 +160,53 @@ func TestHub(t *testing.T) {
 			},
 		},
 		{
+			name: "subscribe_after_source_close_returns_closed_channel",
+			run: func(t *testing.T) {
+				source := make(chan orchestrator.OrchestratorEvent)
+				h := NewHub[orchestrator.OrchestratorEvent](source)
+
+				done := make(chan struct{})
+				go func() {
+					h.Run(context.Background())
+					close(done)
+				}()
+
+				close(source)
+				waitDone(t, done)
+
+				assert.True(t, h.Closed())
+
+				_, sub := h.Subscribe()
+				_, ok := <-sub
+				assert.False(t, ok, "late subscriber must receive an already-closed channel")
+				assert.Equal(t, 0, h.SubscriberCount())
+			},
+		},
+		{
+			name: "subscribe_after_context_cancel_returns_closed_channel",
+			run: func(t *testing.T) {
+				source := make(chan orchestrator.OrchestratorEvent)
+				h := NewHub[orchestrator.OrchestratorEvent](source)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				done := make(chan struct{})
+				go func() {
+					h.Run(ctx)
+					close(done)
+				}()
+
+				cancel()
+				waitDone(t, done)
+
+				assert.True(t, h.Closed())
+
+				_, sub := h.Subscribe()
+				_, ok := <-sub
+				assert.False(t, ok, "late subscriber must receive an already-closed channel")
+				assert.Equal(t, 0, h.SubscriberCount())
+			},
+		},
+		{
 			name: "subscriber_count_tracks_add_and_remove",
 			run: func(t *testing.T) {
 				source := make(chan orchestrator.OrchestratorEvent)

--- a/internal/web/board.go
+++ b/internal/web/board.go
@@ -8,6 +8,10 @@ import (
 	"github.com/junhoyeo/contrabass/internal/tracker"
 )
 
+// maxBoardRequestBytes matches the streamable HTTP cap so a hostile client
+// cannot balloon memory (and the on-disk board store) with a huge payload.
+const maxBoardRequestBytes = 1 << 20
+
 type createBoardIssueRequest struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
@@ -66,6 +70,8 @@ func (s *Server) handleCreateBoardIssue(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxBoardRequestBytes)
+
 	var req createBoardIssueRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body")
@@ -93,6 +99,8 @@ func (s *Server) handleUpdateBoardIssue(w http.ResponseWriter, r *http.Request) 
 		writeJSONError(w, http.StatusBadRequest, "identifier is required")
 		return
 	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBoardRequestBytes)
 
 	var req updateBoardIssueRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/web/board_test.go
+++ b/internal/web/board_test.go
@@ -123,6 +123,31 @@ func TestHandleCreateBoardIssueBadRequest(t *testing.T) {
 	assert.Equal(t, "invalid request body", readErrorMessage(t, rec))
 }
 
+func TestHandleCreateBoardIssueRejectsOversizedBody(t *testing.T) {
+	bp := &fakeBoardProvider{issues: map[string]tracker.LocalBoardIssue{}}
+	body := fmt.Sprintf(`{"title":"huge","description":%q}`, strings.Repeat("a", maxBoardRequestBytes))
+
+	rec := boardRequest(t, bp, http.MethodPost, "/api/v1/board/issues", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, bp.issues, "oversized payload must not be persisted")
+}
+
+func TestHandleUpdateBoardIssueRejectsOversizedBody(t *testing.T) {
+	bp := &fakeBoardProvider{
+		issues: map[string]tracker.LocalBoardIssue{
+			"CB-1": {ID: "CB-1", Identifier: "CB-1", Title: "Old title", State: tracker.LocalBoardStateTodo},
+		},
+	}
+	body := fmt.Sprintf(`{"description":%q}`, strings.Repeat("a", maxBoardRequestBytes))
+
+	rec := boardRequest(t, bp, http.MethodPatch, "/api/v1/board/issues/CB-1", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "Old title", bp.issues["CB-1"].Title)
+	assert.Empty(t, bp.issues["CB-1"].Description)
+}
+
 func TestHandleUpdateBoardIssue(t *testing.T) {
 	bp := &fakeBoardProvider{
 		issues: map[string]tracker.LocalBoardIssue{
@@ -365,7 +390,7 @@ func boardRequestWithServer(
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
-	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req := newLocalWebRequest(method, path, strings.NewReader(body))
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/web/issue_detail_test.go
+++ b/internal/web/issue_detail_test.go
@@ -69,7 +69,7 @@ func TestHandleGetIssueDetails_Success(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/issue-1/details", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/issue-1/details", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -86,7 +86,7 @@ func TestHandleGetIssueDetails_Success(t *testing.T) {
 func TestHandleGetIssueDetails_MissingIssue(t *testing.T) {
 	s := issueDetailTestServer()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/missing/details", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/missing/details", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -97,7 +97,7 @@ func TestHandleGetIssueDetails_MissingIssue(t *testing.T) {
 func TestHandleGetIssueDetails_ProviderUnavailable(t *testing.T) {
 	s := issueDetailTestServer()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/issue-1/details", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/issue-1/details", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -123,7 +123,7 @@ func TestHandleGetIssueTimeline_Success(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -138,7 +138,7 @@ func TestHandleGetIssueTimeline_MissingIssue(t *testing.T) {
 	s := issueDetailTestServer()
 	s.SetTimelineProvider(fakeTimelineProvider{timeline: &timeline.WorkflowTimelineSnapshot{IssueID: "missing"}})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/missing/timeline", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/missing/timeline", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -149,7 +149,7 @@ func TestHandleGetIssueTimeline_MissingIssue(t *testing.T) {
 func TestHandleGetIssueTimeline_ProviderUnavailable(t *testing.T) {
 	s := issueDetailTestServer()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 
@@ -161,7 +161,7 @@ func TestHandleGetIssueTimeline_Error(t *testing.T) {
 	s := issueDetailTestServer()
 	s.SetTimelineProvider(fakeTimelineProvider{err: errors.New("read jsonl: permission denied")})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/issues/issue-1/timeline", nil)
 	rec := httptest.NewRecorder()
 	s.newMux().ServeHTTP(rec, req)
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +20,17 @@ import (
 )
 
 const defaultListenAddr = "localhost:8080"
+
+// allowedOriginsEnv is the escape hatch for serving the dashboard from a
+// different origin (e.g. behind a reverse proxy): a comma-separated list of
+// exact origins such as "https://dash.example.com", or "*" to disable the
+// origin/Host checks entirely. Same-origin and loopback origins are always
+// allowed without configuration.
+const allowedOriginsEnv = "CONTRABASS_ALLOWED_ORIGINS"
+
+// readHeaderTimeout bounds slowloris-style clients that trickle header bytes;
+// it must not bound the response so SSE streams stay open indefinitely.
+const readHeaderTimeout = 10 * time.Second
 
 type SnapshotProvider interface {
 	Snapshot() orchestrator.StateSnapshot
@@ -62,6 +75,11 @@ type Server struct {
 	timelineProvider TimelineProvider
 	mcpTokenMu       sync.Mutex
 	mcpTokens        map[string]mcpTokenRecord
+
+	// extraAllowedOrigins holds operator-configured origins from
+	// CONTRABASS_ALLOWED_ORIGINS; loopback and same-origin requests are
+	// accepted regardless of this list.
+	extraAllowedOrigins []string
 }
 
 func NewServer(
@@ -73,12 +91,25 @@ func NewServer(
 	listenAddr := normalizeListenAddr(addr)
 
 	return &Server{
-		hub:              hub,
-		dashboardFS:      dashboardFS,
-		listenAddr:       listenAddr,
-		snapshotProvider: provider,
-		mcpTokens:        make(map[string]mcpTokenRecord),
+		hub:                 hub,
+		dashboardFS:         dashboardFS,
+		listenAddr:          listenAddr,
+		snapshotProvider:    provider,
+		mcpTokens:           make(map[string]mcpTokenRecord),
+		extraAllowedOrigins: parseAllowedOrigins(os.Getenv(allowedOriginsEnv)),
 	}
+}
+
+func parseAllowedOrigins(raw string) []string {
+	var origins []string
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		origins = append(origins, strings.TrimSuffix(entry, "/"))
+	}
+	return origins
 }
 
 func normalizeListenAddr(addr string) string {
@@ -146,7 +177,7 @@ func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 	}
 
 	mux := s.newMux()
-	s.httpServer = &http.Server{Handler: mux}
+	s.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: readHeaderTimeout}
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -206,17 +237,83 @@ func (s *Server) newMux() *http.ServeMux {
 	return mux
 }
 
+// withCORS gates the plain REST/SSE routes. The dashboard is served from this
+// same server, so cross-origin access is unnecessary by default: only
+// same-origin, loopback, and operator-allowlisted origins pass, and the Host
+// check blocks DNS-rebinding requests that reach us under a foreign name.
 func (s *Server) withCORS(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Mcp-Protocol-Version")
+		if !s.isAllowedAPIRequest(r) {
+			writeJSONError(w, http.StatusForbidden, "origin not allowed")
+			return
+		}
+
+		setExactCORSHeaders(w, r)
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		next(w, r)
 	}
+}
+
+func (s *Server) isAllowedAPIRequest(r *http.Request) bool {
+	if !s.isTrustedHost(r.Host) {
+		return false
+	}
+
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		// Non-browser clients (curl, CLI tooling) and same-origin GET
+		// navigations send no Origin header.
+		return true
+	}
+	if isAllowedExactOrigin(r) {
+		return true
+	}
+	if isLoopbackHost(originHost(origin)) {
+		return true
+	}
+	return s.isExtraAllowedOrigin(origin)
+}
+
+// isTrustedHost rejects requests whose Host header names neither a loopback
+// address, the configured listen host, nor an allowlisted origin's host —
+// the remaining DNS-rebinding vector once the Origin check is in place.
+func (s *Server) isTrustedHost(host string) bool {
+	h := hostWithoutPort(strings.TrimSpace(host))
+	if isLoopbackHost(h) {
+		return true
+	}
+	if listenHost := hostWithoutPort(s.listenAddr); listenHost != "" && strings.EqualFold(h, listenHost) {
+		return true
+	}
+	for _, allowed := range s.extraAllowedOrigins {
+		if allowed == "*" {
+			return true
+		}
+		if strings.EqualFold(h, originHost(allowed)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) isExtraAllowedOrigin(origin string) bool {
+	for _, allowed := range s.extraAllowedOrigins {
+		if allowed == "*" || strings.EqualFold(allowed, origin) {
+			return true
+		}
+	}
+	return false
+}
+
+func originHost(origin string) string {
+	u, err := url.Parse(strings.TrimSpace(origin))
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 func (s *Server) handleGetState(w http.ResponseWriter, _ *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/junhoyeo/contrabass/internal/orchestrator"
+	"github.com/junhoyeo/contrabass/internal/tracker"
 	"github.com/junhoyeo/contrabass/internal/types"
 )
 
@@ -109,7 +110,7 @@ func TestServerRoutes(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, tt.target, nil)
+			req := newLocalWebRequest(tt.method, tt.target, nil)
 			if tt.target == "/api/v1/stream" {
 				req = newLocalWebRequest(tt.method, tt.target, strings.NewReader(`{"jsonrpc":"2.0","id":"ping-1","method":"dashboard.ping"}`))
 				req.Header.Set("Accept", "application/json, text/event-stream")
@@ -120,11 +121,8 @@ func TestServerRoutes(t *testing.T) {
 			h.ServeHTTP(rec, req)
 
 			assert.Equal(t, tt.status, rec.Code)
-			if tt.target == "/api/v1/stream" {
-				assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
-			} else {
-				assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-			}
+			// No Origin header on the request means no CORS grant is echoed.
+			assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
 
 			if tt.status != http.StatusAccepted {
 				assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
@@ -159,15 +157,159 @@ func TestServerCORSPreflight(t *testing.T) {
 	s := &Server{snapshotProvider: provider, dashboardFS: nil}
 	h := s.newMux()
 
-	req := httptest.NewRequest(http.MethodOptions, "/api/v1/refresh", nil)
+	req := newLocalWebRequest(http.MethodOptions, "/api/v1/refresh", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
 	rec := httptest.NewRecorder()
 
 	h.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	// The validated origin is echoed back; the wildcard grant is gone.
+	assert.Equal(t, "http://localhost:8080", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Origin", rec.Header().Get("Vary"))
 	assert.Equal(t, "GET, POST, PATCH, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
 	assert.Equal(t, "Accept, Authorization, Content-Type, Mcp-Protocol-Version", rec.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestWithCORSOriginPolicy(t *testing.T) {
+	tests := []struct {
+		name                string
+		method              string
+		target              string
+		host                string
+		origin              string
+		extraAllowedOrigins []string
+		wantStatus          int
+		wantAllowOrigin     string
+	}{
+		{
+			name:       "no_origin_curl_style_request_allowed",
+			method:     http.MethodGet,
+			target:     "/api/v1/state",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:            "same_origin_mutation_allowed",
+			method:          http.MethodPost,
+			target:          "/api/v1/refresh",
+			origin:          "http://localhost:8080",
+			wantStatus:      http.StatusAccepted,
+			wantAllowOrigin: "http://localhost:8080",
+		},
+		{
+			name:            "loopback_origin_on_other_port_allowed",
+			method:          http.MethodGet,
+			target:          "/api/v1/state",
+			origin:          "http://127.0.0.1:5173",
+			wantStatus:      http.StatusOK,
+			wantAllowOrigin: "http://127.0.0.1:5173",
+		},
+		{
+			name:       "cross_origin_mutation_rejected",
+			method:     http.MethodPost,
+			target:     "/api/v1/refresh",
+			origin:     "https://evil.example",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "cross_origin_sse_rejected",
+			method:     http.MethodGet,
+			target:     "/api/v1/events",
+			origin:     "https://evil.example",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "cross_origin_state_read_rejected",
+			method:     http.MethodGet,
+			target:     "/api/v1/state",
+			origin:     "https://evil.example",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "foreign_host_without_origin_rejected_dns_rebinding",
+			method:     http.MethodGet,
+			target:     "/api/v1/state",
+			host:       "evil.example:8080",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:                "allowlisted_origin_allowed",
+			method:              http.MethodPost,
+			target:              "/api/v1/refresh",
+			origin:              "https://dash.example.com",
+			extraAllowedOrigins: []string{"https://dash.example.com"},
+			wantStatus:          http.StatusAccepted,
+			wantAllowOrigin:     "https://dash.example.com",
+		},
+		{
+			name:                "allowlisted_host_trusted_without_origin",
+			method:              http.MethodGet,
+			target:              "/api/v1/state",
+			host:                "dash.example.com:8080",
+			extraAllowedOrigins: []string{"https://dash.example.com"},
+			wantStatus:          http.StatusOK,
+		},
+		{
+			name:                "wildcard_escape_hatch_restores_allow_all",
+			method:              http.MethodPost,
+			target:              "/api/v1/refresh",
+			host:                "anything.example:8080",
+			origin:              "https://evil.example",
+			extraAllowedOrigins: []string{"*"},
+			wantStatus:          http.StatusAccepted,
+			wantAllowOrigin:     "https://evil.example",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			provider := fakeSnapshotProvider{snapshot: orchestrator.StateSnapshot{Issues: map[string]types.Issue{}}}
+			s := &Server{snapshotProvider: provider, dashboardFS: nil, extraAllowedOrigins: tt.extraAllowedOrigins}
+			h := s.newMux()
+
+			req := newLocalWebRequest(tt.method, tt.target, nil)
+			if tt.host != "" {
+				req.Host = tt.host
+			}
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			assert.Equal(t, tt.wantAllowOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+			if tt.wantStatus == http.StatusForbidden {
+				assert.Equal(t, "origin not allowed", readErrorMessage(t, rec))
+			}
+		})
+	}
+}
+
+func TestWithCORSCrossOriginBoardMutationRejected(t *testing.T) {
+	bp := &fakeBoardProvider{issues: map[string]tracker.LocalBoardIssue{}}
+	s := &Server{snapshotProvider: fakeSnapshotProvider{}, boardProvider: bp}
+	h := s.newMux()
+
+	req := newLocalWebRequest(http.MethodPost, "/api/v1/board/issues", strings.NewReader(`{"title":"pwn"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Empty(t, bp.issues, "cross-origin request must not reach the board provider")
+}
+
+func TestNewServerReadsAllowedOriginsFromEnv(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, " https://dash.example.com/ , https://other.example ,, ")
+
+	s := NewServer("", fakeSnapshotProvider{}, nil, nil)
+
+	assert.Equal(t, []string{"https://dash.example.com", "https://other.example"}, s.extraAllowedOrigins)
 }
 
 func TestNormalizeListenAddr(t *testing.T) {
@@ -309,7 +451,7 @@ func TestHandleStopAgent(t *testing.T) {
 			h := s.newMux()
 
 			target := fmt.Sprintf("/api/v1/running/%s/stop", tt.issueID)
-			req := httptest.NewRequest(http.MethodPost, target, nil)
+			req := newLocalWebRequest(http.MethodPost, target, nil)
 			rec := httptest.NewRecorder()
 
 			h.ServeHTTP(rec, req)
@@ -332,13 +474,28 @@ func TestHandleStopAgent_RejectsBlankIssueID(t *testing.T) {
 
 	// PathValue extracts the issue_id; an explicit blank segment 404s at the
 	// router. Use a whitespace-only segment to drive the BadRequest branch.
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/running/%20/stop", nil)
+	req := newLocalWebRequest(http.MethodPost, "/api/v1/running/%20/stop", nil)
 	rec := httptest.NewRecorder()
 
 	h.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Empty(t, stopper.calls, "blank issue_id must not invoke the stopper")
+}
+
+func TestServeSetsReadHeaderTimeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	provider := fakeSnapshotProvider{snapshot: orchestrator.StateSnapshot{Issues: map[string]types.Issue{}}}
+	server := &Server{snapshotProvider: provider, dashboardFS: nil}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, server.Serve(ctx, listener))
+
+	assert.Equal(t, readHeaderTimeout, server.httpServer.ReadHeaderTimeout)
 }
 
 func TestStartReturnsErrorWhenPortAlreadyInUse(t *testing.T) {

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -23,6 +23,13 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A closed hub never emits again; fail the request so EventSource clients
+	// surface the outage instead of reconnecting into a silent stream.
+	if s.hub.Closed() {
+		writeJSONError(w, http.StatusServiceUnavailable, "event stream is no longer available")
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -41,7 +41,8 @@ func TestHandleSSESetsHeadersAndSendsSnapshot(t *testing.T) {
 	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
 	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", resp.Header.Get("Connection"))
-	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	// No Origin header on the request means no CORS grant is echoed.
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
 
 	frame := readSSEFrame(t, reader)
 	assert.Contains(t, frame, "event: snapshot")
@@ -240,6 +241,31 @@ func TestHandleSSEReturns500WhenFlusherUnsupported(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.status)
 	assert.Contains(t, w.body.String(), "streaming unsupported")
+}
+
+func TestHandleSSEReturns503AfterHubShutdown(t *testing.T) {
+	source := make(chan WebEvent)
+	h := hub.NewHub(source)
+	done := make(chan struct{})
+	go func() {
+		h.Run(context.Background())
+		close(done)
+	}()
+	close(source)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for hub run loop to exit")
+	}
+
+	s := &Server{snapshotProvider: fakeSnapshotProvider{snapshot: orchestrator.StateSnapshot{}}, hub: h, dashboardFS: nil}
+	req := newLocalWebRequest(http.MethodGet, "/api/v1/events", nil)
+	rec := httptest.NewRecorder()
+
+	s.newMux().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "event stream is no longer available")
 }
 
 func TestShouldSkipStaleEvent(t *testing.T) {


### PR DESCRIPTION
Wave 2/3 — security hardening.

**HIGH — wildcard CORS with no Host/Origin validation on state-changing REST and SSE.** The dashboard is same-origin, so the wildcard was pure attack surface: any web page could drive the local API. Now: Host header validated (DNS-rebinding guard), no-Origin (curl/CLI) allowed, same-origin + loopback allowed, everything else rejected 403. Escape hatch: `CONTRABASS_ALLOWED_ORIGINS` (exact origins, or `*` to opt out). Exact CORS headers replace the wildcard.

Also: `SetEventSink` finally has a caller — board mutations now broadcast to SSE clients (the review caught a send-on-closed-channel shutdown race in the first wiring; fixed in the follow-up commit). ReadHeaderTimeout on the HTTP server, MaxBytesReader on board handlers, hub.Subscribe after Run exit returns a closed channel instead of a dead one.

Adversarial review: 1 blocking (the shutdown race) → fixed and re-verified. `go test ./internal/web/... ./internal/hub/... ./cmd/...` green after rebase.