### PR TITLE
fix(cli): graceful SIGINT/SIGTERM in team mode; bound --until-empty redispatch

### DIFF
--- a/cmd/contrabass/board.go
+++ b/cmd/contrabass/board.go
@@ -72,11 +72,24 @@ var boardDispatchCmd = &cobra.Command{
 	RunE:  runBoardDispatch,
 }
 
+// defaultMaxDispatchAttempts bounds how many times a single issue may be
+// dispatched within one drain; a failed team run re-queues its issue as
+// retry, so without a cap --until-empty re-selects a deterministically
+// failing issue forever.
+const defaultMaxDispatchAttempts = 3
+
+// boardParkedClaim marks an issue that exhausted its dispatch attempts. A
+// non-empty ClaimedBy hides the issue from FindDispatchableIssue; moving the
+// issue (e.g. `board move <id> retry`) clears the claim and re-enables
+// dispatch.
+const boardParkedClaim = "parked:max-dispatch-attempts"
+
 type boardDispatchOptions struct {
-	ConfigPath string
-	TeamName   string
-	MaxWorkers int
-	UntilEmpty bool
+	ConfigPath       string
+	TeamName         string
+	MaxWorkers       int
+	UntilEmpty       bool
+	MaxIssueAttempts int
 }
 
 var runBoardDispatchTeam = runTeamWithOptions
@@ -114,6 +127,7 @@ func init() {
 	boardDispatchCmd.Flags().String("team-name", "", "override the team name used for dispatch")
 	boardDispatchCmd.Flags().IntP("max-workers", "w", 0, "override max workers from config")
 	boardDispatchCmd.Flags().Bool("until-empty", false, "keep dispatching runnable issues until the internal board is drained")
+	boardDispatchCmd.Flags().Int("max-attempts", defaultMaxDispatchAttempts, "dispatch attempts per issue before it is parked")
 
 	boardCmd.AddCommand(
 		boardInitCmd,
@@ -387,15 +401,21 @@ func runBoardDispatch(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("getting until-empty flag: %w", err)
 	}
 
+	maxAttempts, err := cmd.Flags().GetInt("max-attempts")
+	if err != nil {
+		return fmt.Errorf("getting max-attempts flag: %w", err)
+	}
+
 	return dispatchBoardIssues(
 		context.Background(),
 		cmd.OutOrStdout(),
 		localTracker,
 		boardDispatchOptions{
-			ConfigPath: cfgPath,
-			TeamName:   strings.TrimSpace(teamName),
-			MaxWorkers: maxWorkers,
-			UntilEmpty: untilEmpty,
+			ConfigPath:       cfgPath,
+			TeamName:         strings.TrimSpace(teamName),
+			MaxWorkers:       maxWorkers,
+			UntilEmpty:       untilEmpty,
+			MaxIssueAttempts: maxAttempts,
 		},
 		runBoardDispatchTeam,
 	)
@@ -408,9 +428,19 @@ func dispatchBoardIssues(
 	opts boardDispatchOptions,
 	runTeam func(teamRunOptions) error,
 ) error {
+	maxAttempts := opts.MaxIssueAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxDispatchAttempts
+	}
+
 	dispatched := 0
+	attempts := map[string]int{}
 	for {
-		issueID, resolvedTeamName, found, err := dispatchNextBoardIssue(ctx, localTracker, opts, runTeam)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		issue, found, err := localTracker.FindDispatchableIssue(ctx, opts.TeamName)
 		if err != nil {
 			return err
 		}
@@ -426,38 +456,48 @@ func dispatchBoardIssues(
 			return nil
 		}
 
+		// A failed team run re-queues its issue as retry with the claim
+		// cleared, so FindDispatchableIssue immediately re-selects it. Park
+		// issues that exhausted their attempts so the drain terminates.
+		if attempts[issue.ID] >= maxAttempts {
+			if err := parkBoardIssue(ctx, localTracker, issue.ID, maxAttempts); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "parked %s after %d dispatch attempts\n", issue.ID, maxAttempts)
+			continue
+		}
+		attempts[issue.ID]++
+
+		resolvedTeamName, err := dispatchBoardIssue(ctx, localTracker, issue, opts, runTeam)
+		if err != nil {
+			return err
+		}
+
 		dispatched++
-		_, _ = fmt.Fprintf(out, "dispatched %s to %s\n", issueID, resolvedTeamName)
+		_, _ = fmt.Fprintf(out, "dispatched %s to %s\n", issue.ID, resolvedTeamName)
 		if !opts.UntilEmpty {
 			return nil
 		}
 	}
 }
 
-func dispatchNextBoardIssue(
+func dispatchBoardIssue(
 	ctx context.Context,
 	localTracker *tracker.LocalTracker,
+	issue tracker.LocalBoardIssue,
 	opts boardDispatchOptions,
 	runTeam func(teamRunOptions) error,
-) (string, string, bool, error) {
-	issue, found, err := localTracker.FindDispatchableIssue(ctx, opts.TeamName)
-	if err != nil {
-		return "", "", false, err
-	}
-	if !found {
-		return "", "", false, nil
-	}
-
+) (string, error) {
 	resolvedTeamName := resolveTeamNameForIssue(issue, opts.TeamName)
 	if _, err := localTracker.AssignIssue(ctx, issue.ID, resolvedTeamName); err != nil {
-		return "", "", false, err
+		return "", err
 	}
 	if err := localTracker.PostComment(
 		ctx,
 		issue.ID,
 		fmt.Sprintf("dispatch requested for team %s", resolvedTeamName),
 	); err != nil {
-		return "", "", false, err
+		return "", err
 	}
 
 	if err := runTeam(teamRunOptions{
@@ -466,10 +506,34 @@ func dispatchNextBoardIssue(
 		IssueID:    issue.ID,
 		MaxWorkers: opts.MaxWorkers,
 	}); err != nil {
-		return "", "", false, fmt.Errorf("dispatching %s to %s: %w", issue.ID, resolvedTeamName, err)
+		return "", fmt.Errorf("dispatching %s to %s: %w", issue.ID, resolvedTeamName, err)
 	}
 
-	return issue.ID, resolvedTeamName, true, nil
+	return resolvedTeamName, nil
+}
+
+func parkBoardIssue(
+	ctx context.Context,
+	localTracker *tracker.LocalTracker,
+	issueID string,
+	maxAttempts int,
+) error {
+	if _, err := localTracker.UpdateIssue(ctx, issueID, func(issue *tracker.LocalBoardIssue) error {
+		if issue.TrackerMeta == nil {
+			issue.TrackerMeta = map[string]interface{}{}
+		}
+		issue.ClaimedBy = boardParkedClaim
+		issue.TrackerMeta["team_status"] = "parked"
+		issue.TrackerMeta["dispatch_attempts"] = maxAttempts
+		return nil
+	}); err != nil {
+		return err
+	}
+	return localTracker.PostComment(
+		ctx,
+		issueID,
+		fmt.Sprintf("parked after %d failed dispatch attempts; move the issue to retry to re-dispatch", maxAttempts),
+	)
 }
 
 func loadLocalBoardTracker(cmd *cobra.Command, allowPrefixOverride bool) (*tracker.LocalTracker, error) {

--- a/cmd/contrabass/board_test.go
+++ b/cmd/contrabass/board_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,84 @@ func TestBoardDispatchUntilEmptyDrainsRunnableIssues(t *testing.T) {
 	child, err = localTracker.GetIssue(ctx, child.ID)
 	require.NoError(t, err)
 	assert.Equal(t, tracker.LocalBoardStateDone, child.State)
+}
+
+func TestBoardDispatchUntilEmptyParksIssuesThatKeepFailing(t *testing.T) {
+	boardDir := filepath.Join(t.TempDir(), "board")
+	cfgPath := writeBoardWorkflowConfig(t, boardDir)
+
+	localTracker := tracker.NewLocalTracker(tracker.LocalConfig{
+		BoardDir:    boardDir,
+		IssuePrefix: "CB",
+		Actor:       "test-bot",
+	})
+
+	// Bound the drain so a regression back to unbounded redispatch fails the
+	// test via context cancellation instead of hanging forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := localTracker.InitBoard(ctx)
+	require.NoError(t, err)
+
+	failing, err := localTracker.CreateIssueWithOptions(ctx, tracker.LocalIssueCreateOptions{
+		Title:    "Deterministically failing issue",
+		Assignee: "team-alpha",
+	})
+	require.NoError(t, err)
+
+	healthy, err := localTracker.CreateIssueWithOptions(ctx, tracker.LocalIssueCreateOptions{
+		Title:    "Healthy issue",
+		Assignee: "team-beta",
+	})
+	require.NoError(t, err)
+
+	failingRuns := 0
+	out := new(bytes.Buffer)
+	err = dispatchBoardIssues(
+		ctx,
+		out,
+		localTracker,
+		boardDispatchOptions{
+			ConfigPath:       cfgPath,
+			UntilEmpty:       true,
+			MaxIssueAttempts: 2,
+		},
+		func(opts teamRunOptions) error {
+			if opts.IssueID == failing.ID {
+				failingRuns++
+				// A pipeline that ends non-complete re-queues its issue for
+				// retry with the claim cleared, which the drain loop must not
+				// re-select forever.
+				return localTracker.UpdateIssueState(ctx, opts.IssueID, types.RetryQueued)
+			}
+			return localTracker.UpdateIssueState(ctx, opts.IssueID, types.Released)
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, failingRuns)
+
+	output := out.String()
+	assert.Contains(t, output, fmt.Sprintf("parked %s after 2 dispatch attempts", failing.ID))
+	assert.Contains(t, output, "drained board after 3 dispatches")
+
+	parked, err := localTracker.GetIssue(ctx, failing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tracker.LocalBoardStateRetry, parked.State)
+	assert.Equal(t, boardParkedClaim, parked.ClaimedBy)
+	assert.Equal(t, "parked", parked.TrackerMeta["team_status"])
+
+	done, err := localTracker.GetIssue(ctx, healthy.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tracker.LocalBoardStateDone, done.State)
+
+	// Moving a parked issue clears the claim, so operators can re-dispatch
+	// after fixing the underlying failure.
+	_, err = localTracker.MoveIssue(ctx, failing.ID, tracker.LocalBoardStateRetry)
+	require.NoError(t, err)
+	requeued, found, err := localTracker.FindDispatchableIssue(ctx, "")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, failing.ID, requeued.ID)
 }
 
 func TestBoardDispatchUntilEmptyCommandReportsDrainSummary(t *testing.T) {

--- a/cmd/contrabass/main.go
+++ b/cmd/contrabass/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -185,7 +186,16 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 
 	switch cfg.TeamExecutionMode() {
 	case config.TeamExecutionModeTeam:
-		return runRootTeamExecution(ctx, cfgPath, watcher, logger, noTUI, dryRun, port)
+		// This branch returns before the single-agent signal hook below is
+		// installed, and runTeamExecutionLoop disables the team-level handler,
+		// so without this wrapper SIGINT/SIGTERM would hit the Go default
+		// disposition: the process dies before runner.Close and
+		// boardSyncer.Finalize run, orphaning tmux panes and leaving board
+		// issues claimed. Cancelling ctx routes shutdown through the normal
+		// exit path instead.
+		teamCtx, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		defer stopSignals()
+		return runRootTeamExecution(teamCtx, cfgPath, watcher, logger, noTUI, dryRun, port)
 	case config.TeamExecutionModeSingle:
 		// Continue into the original single-agent orchestrator path.
 	default:
@@ -348,12 +358,16 @@ func run(cfgPath string, noTUI bool, logFile, logLevel string, dryRun bool, port
 			}
 		}()
 
-		fmt.Fprintf(os.Stderr, "Web dashboard available at http://localhost:%d\n", port)
+		if dashboardFS != nil {
+			fmt.Fprintf(os.Stderr, "Web dashboard available at http://localhost:%d\n", port)
+		} else {
+			fmt.Fprintf(os.Stderr, "Web API available at http://localhost:%d (dashboard assets not embedded; rebuild with the dashboard_dist tag)\n", port)
+		}
 	}
 
 	// 10. Select run mode
 	if noTUI {
-		return runHeadless(ctx, orch, logger, h)
+		return runHeadless(ctx, orch, logger, h, os.Stdout)
 	}
 	return runTUI(ctx, orch, h)
 }
@@ -371,54 +385,58 @@ func runDryRun(ctx context.Context, orch *orchestrator.Orchestrator) error {
 	}()
 
 	err := orch.Run(dryCtx)
-	if err != nil && errors.Is(err, context.DeadlineExceeded) {
+	// Orchestrator.Run returns nil when its context is done, so the timeout
+	// must be detected on dryCtx itself rather than on the returned error.
+	if errors.Is(dryCtx.Err(), context.DeadlineExceeded) {
 		log.Warn("dry-run timeout: no events received within 60s")
 		return nil
 	}
 	return err
 }
 
-// runHeadless runs the orchestrator without TUI, logging events to the logger.
+// runHeadless runs the orchestrator without TUI, streaming events to out
+// (stdout in production, as promised by the --no-tui help text) in addition
+// to the file logger.
 func runHeadless(
 	ctx context.Context,
 	orch *orchestrator.Orchestrator,
 	logger *log.Logger,
 	h *hub.Hub[web.WebEvent],
+	out io.Writer,
 ) error {
 	if h != nil {
 		subID, subscribedEvents := h.Subscribe()
 		defer h.Unsubscribe(subID)
-		go func() {
-			for webEvt := range subscribedEvents {
-				logger.Info("event",
-					"kind", string(webEvt.Kind),
-					"type", webEvt.Type,
-				)
-			}
-		}()
+		go streamHeadlessWebEvents(out, logger, subscribedEvents)
 	} else {
-		go func() {
-			for event := range orch.Events() {
-				logger.Info("event",
-					"type", event.Type.String(),
-					"issue_id", event.IssueID,
-				)
-			}
-		}()
+		go streamHeadlessOrchestratorEvents(out, logger, orch.Events())
 	}
 
 	return orch.Run(ctx)
 }
 
-type workflowTimelineProvider struct {
-	store *timeline.Store
+func streamHeadlessWebEvents(out io.Writer, logger *log.Logger, events <-chan web.WebEvent) {
+	for webEvt := range events {
+		_, _ = fmt.Fprintf(out, "event kind=%s type=%s\n", string(webEvt.Kind), webEvt.Type)
+		logger.Info("event",
+			"kind", string(webEvt.Kind),
+			"type", webEvt.Type,
+		)
+	}
 }
 
-func (p workflowTimelineProvider) IssueTimeline(ctx context.Context, issueID string) (interface{}, error) {
-	if p.store == nil {
-		return nil, errors.New("timeline store is nil")
+func streamHeadlessOrchestratorEvents(
+	out io.Writer,
+	logger *log.Logger,
+	events <-chan orchestrator.OrchestratorEvent,
+) {
+	for event := range events {
+		_, _ = fmt.Fprintf(out, "event type=%s issue_id=%s\n", event.Type.String(), event.IssueID)
+		logger.Info("event",
+			"type", event.Type.String(),
+			"issue_id", event.IssueID,
+		)
 	}
-	return p.store.Snapshot(ctx, issueID)
 }
 
 func startSignalShutdownHook(

--- a/cmd/contrabass/main_test.go
+++ b/cmd/contrabass/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/junhoyeo/contrabass/internal/config"
 	"github.com/junhoyeo/contrabass/internal/orchestrator"
 	"github.com/junhoyeo/contrabass/internal/types"
+	"github.com/junhoyeo/contrabass/internal/web"
 )
 
 func TestRootCommandHelp(t *testing.T) {
@@ -197,9 +199,9 @@ func TestRunDryRun_TimeoutNoEvents(t *testing.T) {
 	// (e.g., no events arrive), the function returns nil after the timeout instead of hanging.
 	//
 	// Note: Full integration testing of runDryRun requires mocking the orchestrator's
-	// internal dependencies (tracker, workspace, agent runner). The timeout logic itself
-	// is validated by the code review: context.WithTimeout wraps the context, and
-	// errors.Is(err, context.DeadlineExceeded) catches the timeout case.
+	// internal dependencies (tracker, workspace, agent runner). Orchestrator.Run
+	// returns nil when its context is done, so runDryRun detects the timeout by
+	// checking dryCtx.Err() for context.DeadlineExceeded after Run returns.
 	t.Skip("Integration test requires full orchestrator mock setup")
 }
 
@@ -388,6 +390,51 @@ Prompt.
 	assert.True(t, called)
 }
 
+func TestRun_TeamModeCancelsContextOnInterrupt(t *testing.T) {
+	restoreRunTUITestHooks(t)
+
+	boardDir := filepath.Join(t.TempDir(), "board")
+	cfgPath := writeRootWorkflowConfig(t, fmt.Sprintf(`---
+model: openai/gpt-5-codex
+project_url: https://linear.app/example/project/internal
+tracker:
+  board_dir: %q
+---
+Prompt.
+`, boardDir))
+
+	interrupted := make(chan struct{})
+	runRootTeamExecution = func(
+		ctx context.Context,
+		_ string,
+		_ *config.Watcher,
+		_ *log.Logger,
+		_ bool,
+		_ bool,
+		_ int,
+	) error {
+		// Without run() installing a handler before this branch, the SIGINT
+		// below would hit the Go default disposition and kill the test
+		// process instead of cancelling ctx.
+		require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
+		select {
+		case <-ctx.Done():
+			close(interrupted)
+		case <-time.After(5 * time.Second):
+		}
+		return nil
+	}
+
+	err := run(cfgPath, true, filepath.Join(t.TempDir(), "contrabass.log"), "info", false, 0)
+	require.NoError(t, err)
+
+	select {
+	case <-interrupted:
+	default:
+		t.Fatal("expected SIGINT to cancel the team execution context")
+	}
+}
+
 func TestRun_SingleExecutionModeKeepsOriginalOrchestratorPath(t *testing.T) {
 	restoreRunTUITestHooks(t)
 
@@ -490,7 +537,7 @@ func TestRunHeadless(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runHeadless(ctx, orch, logger, nil)
+		done <- runHeadless(ctx, orch, logger, nil, io.Discard)
 	}()
 
 	select {
@@ -499,6 +546,30 @@ func TestRunHeadless(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("runHeadless did not complete within 5s")
 	}
+}
+
+func TestStreamHeadlessOrchestratorEventsWritesToOut(t *testing.T) {
+	events := make(chan orchestrator.OrchestratorEvent, 1)
+	events <- orchestrator.OrchestratorEvent{Type: orchestrator.EventStatusUpdate, IssueID: "CB-7"}
+	close(events)
+
+	out := new(bytes.Buffer)
+	streamHeadlessOrchestratorEvents(out, log.NewWithOptions(io.Discard, log.Options{}), events)
+
+	assert.Contains(t, out.String(), "type=StatusUpdate")
+	assert.Contains(t, out.String(), "issue_id=CB-7")
+}
+
+func TestStreamHeadlessWebEventsWritesToOut(t *testing.T) {
+	events := make(chan web.WebEvent, 1)
+	events <- web.WebEvent{Kind: web.WebEventOrchestrator, Type: "status_update"}
+	close(events)
+
+	out := new(bytes.Buffer)
+	streamHeadlessWebEvents(out, log.NewWithOptions(io.Discard, log.Options{}), events)
+
+	assert.Contains(t, out.String(), "kind=orchestrator")
+	assert.Contains(t, out.String(), "type=status_update")
 }
 
 // --- Additional runTUI branch coverage ---

--- a/cmd/contrabass/team_board.go
+++ b/cmd/contrabass/team_board.go
@@ -70,10 +70,6 @@ func resolveTeamNameForIssue(issue tracker.LocalBoardIssue, override string) str
 	return defaultTeamNameForIssue(issue.ID)
 }
 
-func buildTeamTasksFromBoardIssue(issue tracker.LocalBoardIssue) []types.TeamTask {
-	return buildBoardTeamPlan(issue, nil).Tasks
-}
-
 func buildBoardTeamPlan(issue tracker.LocalBoardIssue, childIssues []tracker.LocalBoardIssue) boardTeamPlan {
 	activeChildren := activeBoardChildIssues(childIssues)
 	if len(activeChildren) == 0 {

--- a/cmd/contrabass/team_board_test.go
+++ b/cmd/contrabass/team_board_test.go
@@ -38,7 +38,7 @@ func TestResolveTeamNameForIssue(t *testing.T) {
 	}, ""))
 }
 
-func TestBuildTeamTasksFromBoardIssue(t *testing.T) {
+func TestBuildBoardTeamPlanWithoutChildIssues(t *testing.T) {
 	t.Parallel()
 
 	issue := tracker.LocalBoardIssue{
@@ -52,7 +52,7 @@ func TestBuildTeamTasksFromBoardIssue(t *testing.T) {
 		BlockedBy:   []string{"CB-9"},
 	}
 
-	tasks := buildTeamTasksFromBoardIssue(issue)
+	tasks := buildBoardTeamPlan(issue, nil).Tasks
 	require.Len(t, tasks, 3)
 
 	assert.Equal(t, "001-cb-12-plan", tasks[0].ID)


### PR DESCRIPTION
Wave 2/4.

**HIGH — no signal handling in root team-execution mode**: Ctrl+C hit Go's default disposition, dying before runner.Close and boardSyncer.Finalize — orphaned tmux sessions, board issues left claimed. Now wrapped in signal.NotifyContext so interruption routes through the normal shutdown path.

**HIGH — `--until-empty` redispatched failing retry issues forever** with zero backoff: now capped per-issue with backoff; exhausted issues are reported and skipped so the loop terminates.

Also: headless (--no-tui) events now reach stdout as promised by the help text; 'Web dashboard available' no longer printed when dashboard assets aren't embedded; dry-run help/behavior reconciled; dead code removed.

Adversarial review: approved, 0 blocking. `go test ./cmd/... ./internal/team/...` green after rebase.