### PR TITLE
fix(dashboard): detail-sheet crash on null timeline; stable SSE consumption

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -60,7 +60,17 @@ function App() {
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
             Contrabass
           </p>
-          <p className="mt-2 text-sm">{zhCN.app.sections.runningSessions}…</p>
+          <p className="mt-2 text-sm">{zhCN.app.loading}</p>
+          {error ? (
+            <div className="mt-3 space-y-1" role="alert">
+              <p className="text-xs font-medium text-destructive">
+                {zhCN.app.connectionError}: {error}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {zhCN.app.reconnecting}
+              </p>
+            </div>
+          ) : null}
         </div>
       </div>
     );

--- a/packages/dashboard/src/components/AppLayout.tsx
+++ b/packages/dashboard/src/components/AppLayout.tsx
@@ -47,7 +47,7 @@ interface QueueDef {
 }
 
 export function getLinearState(issue: Issue): string | undefined {
-  const meta = issue.tracker_meta as Record<string, unknown> | undefined;
+  const meta = issue.tracker_meta;
   if (!meta) return undefined;
   const v = meta["linear_state"];
   return typeof v === "string" ? v : undefined;
@@ -72,6 +72,14 @@ function backoffAsRunningRow(entry: BackoffEntry, issue?: Issue): RunningEntry {
     diff_status: "ok",
     phase_label: `attempt ${entry.attempt}`,
   };
+}
+
+// Snapshot issues arrive as a map whose traversal order is arbitrary
+// (lexicographic issue-ID order on the wire), so time-based queues must
+// sort explicitly before truncating.
+function issueUpdatedAtMs(issue: Issue): number {
+  const parsed = Date.parse(issue.updated_at ?? "");
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function issueAsTodoRow(issue: Issue): RunningEntry {
@@ -182,7 +190,10 @@ export function AppLayout({
       recent_done: {
         id: "recent_done",
         title: "最近完成",
-        rows: done.slice(0, 50).map(issueAsTodoRow),
+        rows: [...done]
+          .sort((a, b) => issueUpdatedAtMs(b) - issueUpdatedAtMs(a))
+          .slice(0, 50)
+          .map(issueAsTodoRow),
         emptyText: "暂无近期完成任务",
       },
       canceled: {

--- a/packages/dashboard/src/components/IssueDetailSheet.test.tsx
+++ b/packages/dashboard/src/components/IssueDetailSheet.test.tsx
@@ -173,6 +173,77 @@ describe("IssueDetailSheet", () => {
     }
   });
 
+  it("renders the empty-timeline state when the API returns null collections", async () => {
+    const { restore } = installFetchMock((url) => {
+      if (url.endsWith("/details")) {
+        return jsonResponse({
+          issue: baseIssue(),
+          generated_at: "2026-03-05T10:06:00.000Z",
+        });
+      }
+      // Go marshals nil slices as null for issues with no workflow history.
+      return jsonResponse({
+        issue_id: "issue-1",
+        runs: null,
+        nodes: null,
+        run_sync_states: null,
+        node_sync_states: null,
+        generated_at: "2026-03-05T10:06:00.000Z",
+      });
+    });
+
+    try {
+      render(<IssueDetailSheet data={sheetData()} onOpenChange={() => {}} />);
+
+      await waitFor(() => {
+        expectInDocument(screen.getByText(zhCN.detail.noTimeline));
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not refetch when sheet data object identity changes for the same issue", async () => {
+    const { fetchMock, restore } = installFetchMock((url) => {
+      if (url.endsWith("/details")) {
+        return jsonResponse({
+          issue: { ...baseIssue(), title: "Loaded issue title" },
+          generated_at: "2026-03-05T10:06:00.000Z",
+        });
+      }
+      return jsonResponse({
+        issue_id: "issue-1",
+        runs: [],
+        nodes: [],
+        run_sync_states: [],
+        node_sync_states: [],
+        generated_at: "2026-03-05T10:06:00.000Z",
+      });
+    });
+
+    try {
+      const { rerender } = render(
+        <IssueDetailSheet data={sheetData()} onOpenChange={() => {}} />,
+      );
+
+      await waitFor(() => {
+        expectInDocument(screen.getByText("Loaded issue title"));
+      });
+      const callsAfterLoad = fetchMock.mock.calls.length;
+
+      // Every accepted SSE snapshot rebuilds sheetData with a fresh object
+      // identity; the fetch effect must key on the stable issue id so open
+      // sheets do not flicker back to their loading states.
+      rerender(<IssueDetailSheet data={sheetData()} onOpenChange={() => {}} />);
+
+      expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+      expect(screen.queryByText(zhCN.detail.loadingDetails)).toBeNull();
+      expectInDocument(screen.getByText("Loaded issue title"));
+    } finally {
+      restore();
+    }
+  });
+
   it("shows inline non-blocking errors for failed detail and timeline fetches", async () => {
     const { restore } = installFetchMock((url) => {
       if (url.endsWith("/details")) {
@@ -408,6 +479,61 @@ describe("IssueDetailSheet — Stop button", () => {
       });
 
       resolveStop();
+    } finally {
+      restore();
+    }
+  });
+
+  it("clears a stale stop error when the sheet targets another issue", async () => {
+    const { restore } = installFetchMock((url) => {
+      if (url.includes("/stop")) {
+        return jsonResponse({ error: "not running" }, 404);
+      }
+      if (url.endsWith("/timeline")) {
+        return jsonResponse({
+          issue_id: "ISS-RUN-1",
+          runs: [],
+          nodes: [],
+          run_sync_states: [],
+          node_sync_states: [],
+          generated_at: "",
+        });
+      }
+      return jsonResponse({ issue: baseIssue(), generated_at: "" });
+    });
+
+    try {
+      const { rerender } = render(
+        <IssueDetailSheet
+          data={runningSheetData()}
+          onOpenChange={() => {}}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: zhCN.detail.stopAgent }),
+      );
+
+      await waitFor(() => {
+        expectInDocument(
+          screen.getByText(zhCN.detail.stopFailed("not running")),
+        );
+      });
+
+      // Close-and-reopen on another running agent: the previous issue's
+      // failure must not render under the new issue's stop button.
+      rerender(
+        <IssueDetailSheet
+          data={runningSheetData(baseRunningEntry({ issue_id: "ISS-RUN-2" }))}
+          onOpenChange={() => {}}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(zhCN.detail.stopFailed("not running")),
+        ).toBeNull();
+      });
     } finally {
       restore();
     }

--- a/packages/dashboard/src/components/IssueDetailSheet.tsx
+++ b/packages/dashboard/src/components/IssueDetailSheet.tsx
@@ -124,11 +124,6 @@ export function IssueDetailSheet({
     }
   }
 
-  useEffect(() => {
-    if (kind !== "running") {
-      setStopping(false);
-    }
-  }, [kind]);
   const loadedIssue = detailState.data?.issue;
   const displayedIssue = loadedIssue ?? issue;
   const linearState = displayedIssue
@@ -136,8 +131,18 @@ export function IssueDetailSheet({
     : undefined;
   const issueID = selectedIssueID(data);
 
+  // Stop state is per-issue: a stale error or in-flight flag from one issue
+  // must not carry over when the sheet targets another one.
   useEffect(() => {
-    if (!data || !issueID) {
+    setStopping(false);
+    setStopError(null);
+  }, [kind, issueID]);
+
+  // Keyed on issueID only: `data` gets a new object identity on every SSE
+  // snapshot, which would abort and restart these fetches while the sheet
+  // stays on the same issue. issueID is "" whenever data is null.
+  useEffect(() => {
+    if (!issueID) {
       setDetailState(emptyDetailState);
       setTimelineState(emptyTimelineState);
       return;
@@ -172,7 +177,19 @@ export function IssueDetailSheet({
       controller.signal,
     )
       .then((payload) =>
-        setTimelineState({ loading: false, data: payload, error: null }),
+        // Go marshals nil slices as null (issues with no workflow history);
+        // normalize so render code can index the collections safely.
+        setTimelineState({
+          loading: false,
+          data: {
+            ...payload,
+            runs: payload.runs ?? [],
+            nodes: payload.nodes ?? [],
+            run_sync_states: payload.run_sync_states ?? [],
+            node_sync_states: payload.node_sync_states ?? [],
+          },
+          error: null,
+        }),
       )
       .catch((error: unknown) => {
         if (!controller.signal.aborted) {
@@ -186,7 +203,7 @@ export function IssueDetailSheet({
       });
 
     return () => controller.abort();
-  }, [data, issueID]);
+  }, [issueID]);
 
   return (
     <Sheet open={data !== null} onOpenChange={onOpenChange}>

--- a/packages/dashboard/src/components/QueuePanel.test.tsx
+++ b/packages/dashboard/src/components/QueuePanel.test.tsx
@@ -14,10 +14,15 @@ async function waitForQueueTick() {
   });
 }
 
+// seq mirrors useSSE's monotonic counter; each fabricated event gets a fresh
+// one unless the test pins it explicitly.
+let nextSeq = 0;
+
 function queueEvent(
   overrides: Partial<QueueEventPayload> = {},
 ): QueueEventPayload {
   return {
+    seq: nextSeq++,
     issue_id: "issue-1",
     identifier: "ZII-50",
     blockers: "ZII-49",
@@ -91,5 +96,23 @@ describe("QueuePanel", () => {
     nowMs = 10_000;
     await waitForQueueTick();
     expect(screen.queryByText("ZII-50")).toBeNull();
+  });
+
+  it("keeps processing events after the buffer is trimmed from the front", async () => {
+    const first = queueEvent({ issue_id: "issue-a", identifier: "ZII-60" });
+    const second = queueEvent({ issue_id: "issue-b", identifier: "ZII-61" });
+    const { rerender } = render(<QueuePanel events={[first, second]} />);
+    expectInDocument(screen.getByText("ZII-60"));
+    expectInDocument(screen.getByText("ZII-61"));
+
+    // Simulate the useSSE ring buffer at capacity: the oldest entry is
+    // spliced off the front while a new one is appended, so the array
+    // length stays constant and index-based cursors would stall.
+    const third = queueEvent({ issue_id: "issue-c", identifier: "ZII-62" });
+    await act(async () => {
+      rerender(<QueuePanel events={[second, third]} />);
+    });
+
+    expectInDocument(screen.getByText("ZII-62"));
   });
 });

--- a/packages/dashboard/src/components/QueuePanel.tsx
+++ b/packages/dashboard/src/components/QueuePanel.tsx
@@ -28,7 +28,7 @@ export function QueuePanel({
   now = Date.now,
   ttlMs = 5_000,
 }: QueuePanelProps) {
-  const processedCount = useRef(0);
+  const lastSeenSeq = useRef(-1);
   const nowRef = useRef(now);
   const rowsRef = useRef<QueueRow[]>([]);
   const [rows, setRows] = useState<QueueRow[]>([]);
@@ -38,11 +38,13 @@ export function QueuePanel({
   }, [now]);
 
   useEffect(() => {
-    const pending = events.slice(processedCount.current);
-    processedCount.current = Math.min(processedCount.current + pending.length, events.length);
+    // Consume by sequence id, not array index: useSSE trims the buffer from
+    // the front once full, so indices do not survive across renders.
+    const pending = events.filter((event) => event.seq > lastSeenSeq.current);
     if (pending.length === 0) {
       return;
     }
+    lastSeenSeq.current = pending[pending.length - 1].seq;
 
     const seenAt = nowRef.current();
     setRows((current) => {

--- a/packages/dashboard/src/hooks/useSSE.test.ts
+++ b/packages/dashboard/src/hooks/useSSE.test.ts
@@ -412,6 +412,35 @@ describe('useSSE state helpers', () => {
     }
   })
 
+  it('re-syncs board issues after the stream reconnects', async () => {
+    const firstStream = new MockStreamableHTTP()
+    const secondStream = new MockStreamableHTTP()
+    const mockFetch = installStreamableFetch([firstStream, secondStream])
+
+    try {
+      renderHook(() => useSSE())
+
+      await waitFor(() => {
+        expect(mockFetch.calls.filter((call) => call.url === '/api/v1/board/issues')).toHaveLength(1)
+      })
+      firstStream.close()
+
+      // Board events published while disconnected are lost (no hub replay),
+      // so every successful reconnect must refetch the board snapshot.
+      await waitFor(
+        () => {
+          expect(mockFetch.calls.filter((call) => call.url === '/api/v1/board/issues')).toHaveLength(2)
+        },
+        { timeout: 1500 },
+      )
+    } finally {
+      firstStream.close()
+      secondStream.close()
+      mockFetch.restore()
+      cleanup()
+    }
+  })
+
   it('handles all orchestrator event types in applyEvent', () => {
     const snapshot = makeSnapshot()
 
@@ -659,7 +688,7 @@ describe('useSSE state helpers', () => {
     expect(next.state?.running.find((entry) => entry.issue_id === 'ISSUE-9')).toBeTruthy()
   })
 
-  it('records queue channel events', () => {
+  it('records queue channel events with monotonically increasing sequence ids', () => {
     const next = sseReducer(INITIAL_STATE, {
       type: 'web_event',
       data: makeWebEvent('orchestrator', 'dispatch_skipped_blocked_by', {
@@ -669,13 +698,26 @@ describe('useSSE state helpers', () => {
       }),
     })
 
-    expect(next.queueEvents).toEqual([
-      {
-        issue_id: 'issue-50',
-        identifier: 'ZII-50',
-        blockers: 'ZII-49,ZII-48',
-      },
-    ])
+    expect(next.queueEvents).toHaveLength(1)
+    expect(next.queueEvents[0]).toMatchObject({
+      issue_id: 'issue-50',
+      identifier: 'ZII-50',
+      blockers: 'ZII-49,ZII-48',
+    })
+
+    const after = sseReducer(next, {
+      type: 'web_event',
+      data: makeWebEvent('orchestrator', 'dispatch_skipped_blocked_by', {
+        issue_id: 'issue-51',
+        identifier: 'ZII-51',
+        blockers: 'ZII-50',
+      }),
+    })
+
+    // Consumers track their position by seq because the ring buffer trims
+    // entries from the front once full; indices are not stable.
+    expect(after.queueEvents).toHaveLength(2)
+    expect(after.queueEvents[1].seq).toBeGreaterThan(after.queueEvents[0].seq)
   })
 
   it('updates teamSnapshot for team events', () => {

--- a/packages/dashboard/src/hooks/useSSE.ts
+++ b/packages/dashboard/src/hooks/useSSE.ts
@@ -77,6 +77,9 @@ interface StreamableHTTPMessage {
 }
 
 export interface QueueEventPayload {
+  // Monotonic id: consumers must track position by seq, not array index,
+  // because the queueEvents ring buffer trims entries from the front.
+  seq: number
   issue_id: string
   identifier: string
   blockers: string
@@ -573,6 +576,10 @@ function applyAgentLogEvent(state: SSEState, webEvt: WebEvent): SSEState {
   return appendAgentLog(state, logEvent)
 }
 
+// Module-level so seq survives reducer re-runs; gaps (e.g. from StrictMode
+// double-invocation) are fine — only monotonicity matters.
+let nextQueueEventSeq = 0
+
 function applyQueueEvent(state: SSEState, webEvt: WebEvent): SSEState {
   const payload = asRecord(webEvt.payload)
   const issueID = typeof payload.issue_id === 'string' ? payload.issue_id : ''
@@ -581,6 +588,7 @@ function applyQueueEvent(state: SSEState, webEvt: WebEvent): SSEState {
   }
 
   const entry: QueueEventPayload = {
+    seq: nextQueueEventSeq++,
     issue_id: issueID,
     identifier: typeof payload.identifier === 'string' ? payload.identifier : issueID,
     blockers: typeof payload.blockers === 'string' ? payload.blockers : '',
@@ -851,6 +859,11 @@ export function useSSE() {
         return
       }
 
+      // Only a parsed message proves the stream is healthy; resetting on the
+      // HTTP 200 alone would defeat exponential backoff against a server that
+      // accepts the request and then immediately drops the body.
+      reconnectAttemptRef.current = 0
+
       switch (message.method) {
         case 'dashboard.snapshot':
           {
@@ -895,7 +908,9 @@ export function useSSE() {
         }
 
         dispatch({ type: 'connected' })
-        reconnectAttemptRef.current = 0
+        // Board events published while disconnected are lost (the hub has no
+        // replay buffer), so re-sync the board on every successful (re)connect.
+        void refreshBoardIssues(controller.signal)
         await readStreamableHTTPResponse(response, handleMessage)
         dispatch({ type: 'disconnected' })
         scheduleReconnect(controller)
@@ -911,7 +926,7 @@ export function useSSE() {
         }
       }
     })()
-  }, [clearReconnectTimer, scheduleReconnect])
+  }, [clearReconnectTimer, refreshBoardIssues, scheduleReconnect])
 
   useEffect(() => {
     connectRef.current = connect
@@ -926,12 +941,6 @@ export function useSSE() {
       clearReconnectTimer()
     }
   }, [connect, clearReconnectTimer])
-
-  useEffect(() => {
-    const controller = new AbortController()
-    void refreshBoardIssues(controller.signal)
-    return () => controller.abort()
-  }, [refreshBoardIssues])
 
   // Per-issue tokens (running[i].tokens_in/out) and diff stats are only
   // populated in the initial /api/v1/state snapshot — the StatusUpdate SSE

--- a/packages/dashboard/src/i18n/messages.ts
+++ b/packages/dashboard/src/i18n/messages.ts
@@ -1,6 +1,8 @@
 export const zhCN = {
   app: {
     connectionError: "连接错误",
+    loading: "正在加载运行状态…",
+    reconnecting: "连接失败，正在自动重试…",
     sections: {
       runningSessions: "运行会话",
       board: "看板",

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -65,13 +65,15 @@ export interface Issue {
   description: string;
   state: number;
   priority?: number;
-  labels: string[];
+  // Go marshals nil slices/maps as null and the runtime validator admits it;
+  // the declared type must match so new code cannot trust a bare array/object.
+  labels?: string[] | null;
   url: string;
   branch_name?: string;
   blocked_by?: string[];
   created_at?: string;
   updated_at?: string;
-  tracker_meta: Record<string, unknown>;
+  tracker_meta?: Record<string, unknown> | null;
 }
 
 export interface LinearUserSummary {


### PR DESCRIPTION
Wave 2/5 — dashboard (Ziikoo) fixes.

**HIGH — detail sheet crashed with a TypeError** whenever the timeline API returned `"nodes": null` (any issue with no workflow history). **HIGH — the detail/timeline fetch effect keyed on object identity of `data`**, refetching + flashing the loading state on every SSE snapshot; now keyed on stable identifiers.

Also: connection errors are visible before the first snapshot (no more eternal loading card when the backend is down), '最近完成' sorts by recency instead of object-key order, queue events carry monotonic sequence numbers so QueuePanel keeps consuming past the 1000-entry ring-buffer cap, board issues re-fetch after stream reconnect, stop-button state resets, reconnect backoff only resets after the stream proves stable, Issue.labels/tracker_meta nullability matches Go's JSON.

Adversarial review: approved, 0 blocking. Typecheck + production build green after rebase.